### PR TITLE
bench: Modify BenchmarkAggregateBatch to not harvest and bench concurrency

### DIFF
--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -11,7 +11,6 @@ import (
 	"net/netip"
 	"sort"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1188,7 +1187,7 @@ func BenchmarkAggregateCombinedMetrics(b *testing.B) {
 	}
 }
 
-func benchmarkAggregateBatchConcurrent(b *testing.B, concurrency int) {
+func BenchmarkAggregateBatchSerial(b *testing.B) {
 	b.ReportAllocs()
 	agg, err := New(AggregatorConfig{
 		DataDir: b.TempDir(),
@@ -1218,21 +1217,13 @@ func benchmarkAggregateBatchConcurrent(b *testing.B, concurrency int) {
 			},
 		},
 	}
-	wg := sync.WaitGroup{}
 	b.ResetTimer()
 
-	for j := 0; j < concurrency; j++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for i := 0; i < b.N; i++ {
-				if err := agg.AggregateBatch(context.Background(), "test", batch); err != nil {
-					b.Fatal(err)
-				}
-			}
-		}()
+	for i := 0; i < b.N; i++ {
+		if err := agg.AggregateBatch(context.Background(), "test", batch); err != nil {
+			b.Fatal(err)
+		}
 	}
-	wg.Wait()
 
 	if agg.batch != nil {
 		if err := agg.batch.Commit(pebble.Sync); err != nil {
@@ -1248,11 +1239,57 @@ func benchmarkAggregateBatchConcurrent(b *testing.B, concurrency int) {
 	}
 }
 
-func BenchmarkAggregateBatchConcurrent(b *testing.B) {
-	for _, concurrency := range []int{1, 10, 100, 1000} {
-		b.Run(fmt.Sprintf("%d", concurrency), func(b *testing.B) {
-			benchmarkAggregateBatchConcurrent(b, concurrency)
-		})
+func BenchmarkAggregateBatchParallel(b *testing.B) {
+	b.ReportAllocs()
+	agg, err := New(AggregatorConfig{
+		DataDir: b.TempDir(),
+		Limits: Limits{
+			MaxSpanGroups:                         1000,
+			MaxSpanGroupsPerService:               100,
+			MaxTransactionGroups:                  1000,
+			MaxTransactionGroupsPerService:        100,
+			MaxServiceTransactionGroups:           1000,
+			MaxServiceTransactionGroupsPerService: 100,
+			MaxServices:                           100,
+			MaxServiceInstanceGroupsPerService:    100,
+		},
+		Processor:            noOpProcessor(),
+		AggregationIntervals: []time.Duration{time.Second, time.Minute, time.Hour},
+	}, zap.NewNop())
+	if err != nil {
+		b.Fatal(err)
+	}
+	batch := &modelpb.Batch{
+		&modelpb.APMEvent{
+			Processor: modelpb.TransactionProcessor(),
+			Event:     &modelpb.Event{Duration: durationpb.New(time.Millisecond)},
+			Transaction: &modelpb.Transaction{
+				Name:                "T-1000",
+				RepresentativeCount: 1,
+			},
+		},
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := agg.AggregateBatch(context.Background(), "test", batch); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	if agg.batch != nil {
+		if err := agg.batch.Commit(pebble.Sync); err != nil {
+			b.Fatal(err)
+		}
+		if err := agg.batch.Close(); err != nil {
+			b.Fatal(err)
+		}
+		agg.batch = nil
+	}
+	if err := agg.db.Close(); err != nil {
+		b.Fatal(err)
 	}
 }
 

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/cockroachdb/pebble"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -1028,6 +1030,7 @@ func TestRunStopOrchestration(t *testing.T) {
 }
 
 func BenchmarkAggregateCombinedMetrics(b *testing.B) {
+	b.ReportAllocs()
 	gatherer, err := apmotel.NewGatherer()
 	if err != nil {
 		b.Fatal(err)
@@ -1048,6 +1051,7 @@ func BenchmarkAggregateCombinedMetrics(b *testing.B) {
 		}),
 		WithProcessor(noOpProcessor()),
 		WithMeter(mp.Meter("test")),
+		WithLogger(zap.NewNop()),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -1104,6 +1108,7 @@ func BenchmarkAggregateBatchSerial(b *testing.B) {
 		}),
 		WithProcessor(noOpProcessor()),
 		WithAggregationIntervals([]time.Duration{time.Second, time.Minute, time.Hour}),
+		WithLogger(zap.NewNop()),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -1156,6 +1161,7 @@ func BenchmarkAggregateBatchParallel(b *testing.B) {
 		}),
 		WithProcessor(noOpProcessor()),
 		WithAggregationIntervals([]time.Duration{time.Second, time.Minute, time.Hour}),
+		WithLogger(zap.NewNop()),
 	)
 	if err != nil {
 		b.Fatal(err)

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -1089,58 +1089,15 @@ func BenchmarkAggregateCombinedMetrics(b *testing.B) {
 }
 
 func BenchmarkAggregateBatchSerial(b *testing.B) {
-	b.ReportAllocs()
-	agg, err := New(
-		WithDataDir(b.TempDir()),
-		WithLimits(Limits{
-			MaxSpanGroups:                         1000,
-			MaxSpanGroupsPerService:               100,
-			MaxTransactionGroups:                  1000,
-			MaxTransactionGroupsPerService:        100,
-			MaxServiceTransactionGroups:           1000,
-			MaxServiceTransactionGroupsPerService: 100,
-			MaxServices:                           100,
-			MaxServiceInstanceGroupsPerService:    100,
-		}),
-		WithProcessor(noOpProcessor()),
-		WithAggregationIntervals([]time.Duration{time.Second, time.Minute, time.Hour}),
-	)
-	if err != nil {
-		b.Fatal(err)
-	}
-	batch := &modelpb.Batch{
-		&modelpb.APMEvent{
-			Processor: modelpb.TransactionProcessor(),
-			Event:     &modelpb.Event{Duration: durationpb.New(time.Millisecond)},
-			Transaction: &modelpb.Transaction{
-				Name:                "T-1000",
-				RepresentativeCount: 1,
-			},
-		},
-	}
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		if err := agg.AggregateBatch(context.Background(), "test", batch); err != nil {
-			b.Fatal(err)
-		}
-	}
-
-	if agg.batch != nil {
-		if err := agg.batch.Commit(pebble.Sync); err != nil {
-			b.Fatal(err)
-		}
-		if err := agg.batch.Close(); err != nil {
-			b.Fatal(err)
-		}
-		agg.batch = nil
-	}
-	if err := agg.db.Close(); err != nil {
-		b.Fatal(err)
-	}
+	b.SetParallelism(1)
+	benchmarkAggregateBatchParallel(b)
 }
 
 func BenchmarkAggregateBatchParallel(b *testing.B) {
+	benchmarkAggregateBatchParallel(b)
+}
+
+func benchmarkAggregateBatchParallel(b *testing.B) {
 	b.ReportAllocs()
 	agg, err := New(
 		WithDataDir(b.TempDir()),

--- a/aggregators/codec_test.go
+++ b/aggregators/codec_test.go
@@ -69,6 +69,7 @@ func TestHistogramRepresentation(t *testing.T) {
 }
 
 func BenchmarkCombinedMetricsEncoding(b *testing.B) {
+	b.ReportAllocs()
 	ts := time.Now()
 	cardinality := 10
 	tcm := createTestCombinedMetrics()
@@ -89,6 +90,7 @@ func BenchmarkCombinedMetricsEncoding(b *testing.B) {
 }
 
 func BenchmarkCombinedMetricsDecoding(b *testing.B) {
+	b.ReportAllocs()
 	ts := time.Now()
 	cardinality := 10
 	tcm := createTestCombinedMetrics()


### PR DESCRIPTION
- BenchmarkAggregateBatch* should not harvest, for a more stable benchmark
- Rename BenchmarkAggregateBatch to BenchmarkAggregateBatchSerial
- Add BenchmarkAggregateBatchParallel