### PR TITLE
Optimize histogram to record single values

### DIFF
--- a/aggregators/codec_test.go
+++ b/aggregators/codec_test.go
@@ -65,7 +65,12 @@ func TestHistogramRepresentation(t *testing.T) {
 
 	actual := hdrhistogram.New()
 	HistogramFromProto(actual, HistogramToProto(expected))
-	assert.Empty(t, cmp.Diff(expected, actual))
+	assert.Empty(t, cmp.Diff(
+		expected, actual,
+		cmp.Comparer(func(a, b hdrhistogram.HybridCountsRep) bool {
+			return a.Equal(&b)
+		}),
+	))
 }
 
 func BenchmarkCombinedMetricsEncoding(b *testing.B) {

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -56,6 +56,9 @@ func TestEventToCombinedMetrics(t *testing.T) {
 	assert.Empty(t, cmp.Diff(
 		expected, cm,
 		cmpopts.EquateEmpty(),
+		cmp.Comparer(func(a, b hdrhistogram.HybridCountsRep) bool {
+			return a.Equal(&b)
+		}),
 		cmp.AllowUnexported(CombinedMetrics{}),
 	))
 }

--- a/aggregators/internal/hdrhistogram/hdrhistogram_test.go
+++ b/aggregators/internal/hdrhistogram/hdrhistogram_test.go
@@ -84,9 +84,9 @@ func getTestHistogram() *hdrhistogram.Histogram {
 
 func convertHistogramRepToSnapshot(h *HistogramRepresentation) *hdrhistogram.Snapshot {
 	counts := make([]int64, countsLen)
-	for b, n := range h.CountsRep {
-		counts[b] += n
-	}
+	h.CountsRep.ForEach(func(bucket int32, value int64) {
+		counts[bucket] += value
+	})
 	return &hdrhistogram.Snapshot{
 		LowestTrackableValue:  h.LowestTrackableValue,
 		HighestTrackableValue: h.HighestTrackableValue,

--- a/aggregators/merger_test.go
+++ b/aggregators/merger_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-aggregation/aggregators/internal/hdrhistogram"
 	"github.com/elastic/apm-data/model/modelpb"
 )
 
@@ -471,7 +472,13 @@ func TestMerge(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			merge(&tc.to, &tc.from, tc.limits)
-			assert.Empty(t, cmp.Diff(tc.expected, tc.to, cmp.Exporter(func(reflect.Type) bool { return true })))
+			assert.Empty(t, cmp.Diff(
+				tc.expected, tc.to,
+				cmp.Exporter(func(reflect.Type) bool { return true }),
+				cmp.Comparer(func(a, b hdrhistogram.HybridCountsRep) bool {
+					return a.Equal(&b)
+				}),
+			))
 		})
 	}
 }


### PR DESCRIPTION
Instead of allocating values in a map for the first APMEvent received, we record the value as integers in the hybrid representation. The complexity of the approach is wrapped in a set of methods for ease of use.

Benchmarks:

```
name                        old time/op    new time/op    delta
CombinedMetricsEncoding-10    5.73µs ± 1%    5.70µs ± 2%     ~     (p=0.090 n=9+10)
CombinedMetricsDecoding-10    6.38µs ± 3%    5.12µs ± 4%  -19.84%  (p=0.000 n=10+10)
CombinedMetricsToBatch-10      352µs ± 1%     364µs ± 1%   +3.20%  (p=0.000 n=10+9)
EventToCombinedMetrics-10     1.25µs ± 2%    1.13µs ± 3%  -10.09%  (p=0.000 n=10+9)

name                        old alloc/op   new alloc/op   delta
CombinedMetricsEncoding-10    2.77kB ± 0%    2.77kB ± 0%     ~     (all equal)
CombinedMetricsDecoding-10    13.1kB ± 0%    10.3kB ± 0%  -21.93%  (p=0.000 n=8+9)
CombinedMetricsToBatch-10     39.7kB ± 0%    39.7kB ± 0%     ~     (all equal)
EventToCombinedMetrics-10     3.42kB ± 0%    3.14kB ± 0%   -8.44%  (p=0.000 n=10+10)

name                        old allocs/op  new allocs/op  delta
CombinedMetricsEncoding-10      79.0 ± 0%      79.0 ± 0%     ~     (all equal)
CombinedMetricsDecoding-10      80.0 ± 0%      40.0 ± 0%  -50.00%  (p=0.000 n=10+10)
CombinedMetricsToBatch-10        339 ± 0%       339 ± 0%     ~     (all equal)
EventToCombinedMetrics-10       19.0 ± 0%      15.0 ± 0%  -21.05%  (p=0.000 n=10+10)
```