### PR TITLE
Fix vtproto pooling to reduce allocs

### DIFF
--- a/aggregationpb/aggregation_vtproto.pb.go
+++ b/aggregationpb/aggregation_vtproto.pb.go
@@ -1352,13 +1352,16 @@ var vtprotoPool_CombinedMetrics = sync.Pool{
 }
 
 func (m *CombinedMetrics) ResetVT() {
-	for _, mm := range m.ServiceMetrics {
-		mm.ResetVT()
+	for k, mm := range m.ServiceMetrics {
+		mm.ReturnToVTPool()
+		m.ServiceMetrics[k] = nil
 	}
+	f1 := m.ServiceMetrics[:0]
 	m.OverflowServices.ReturnToVTPool()
 	f0 := m.OverflowServiceInstancesEstimator[:0]
 	m.Reset()
 	m.OverflowServiceInstancesEstimator = f0
+	m.ServiceMetrics = f1
 }
 func (m *CombinedMetrics) ReturnToVTPool() {
 	if m != nil {
@@ -1419,11 +1422,14 @@ var vtprotoPool_ServiceMetrics = sync.Pool{
 }
 
 func (m *ServiceMetrics) ResetVT() {
-	for _, mm := range m.ServiceInstanceMetrics {
-		mm.ResetVT()
+	for k, mm := range m.ServiceInstanceMetrics {
+		mm.ReturnToVTPool()
+		m.ServiceInstanceMetrics[k] = nil
 	}
+	f0 := m.ServiceInstanceMetrics[:0]
 	m.OverflowGroups.ReturnToVTPool()
 	m.Reset()
+	m.ServiceInstanceMetrics = f0
 }
 func (m *ServiceMetrics) ReturnToVTPool() {
 	if m != nil {
@@ -1463,16 +1469,25 @@ var vtprotoPool_ServiceInstanceMetrics = sync.Pool{
 }
 
 func (m *ServiceInstanceMetrics) ResetVT() {
-	for _, mm := range m.TransactionMetrics {
-		mm.ResetVT()
+	for k, mm := range m.TransactionMetrics {
+		mm.ReturnToVTPool()
+		m.TransactionMetrics[k] = nil
 	}
-	for _, mm := range m.ServiceTransactionMetrics {
-		mm.ResetVT()
+	for k, mm := range m.ServiceTransactionMetrics {
+		mm.ReturnToVTPool()
+		m.ServiceTransactionMetrics[k] = nil
 	}
-	for _, mm := range m.SpanMetrics {
-		mm.ResetVT()
+	for k, mm := range m.SpanMetrics {
+		mm.ReturnToVTPool()
+		m.SpanMetrics[k] = nil
 	}
+	f0 := m.TransactionMetrics[:0]
+	f1 := m.ServiceTransactionMetrics[:0]
+	f2 := m.SpanMetrics[:0]
 	m.Reset()
+	m.TransactionMetrics = f0
+	m.ServiceTransactionMetrics = f1
+	m.SpanMetrics = f2
 }
 func (m *ServiceInstanceMetrics) ReturnToVTPool() {
 	if m != nil {


### PR DESCRIPTION
I'm convinced that vtproto pooling is bugged:
- KeyedServiceMetrics and KeyedServiceInstanceMetrics are never returned to pool.
- One might argue that the array should be reused instead of the individual elements, but `m.Reset()` just throws away the reference to the backing array by doing `*x=MyStruct{}`. So nothing is reused.
- This ultimately leads to ineffective pooling and lots of allocs.

Ideally this should be fixed in vtproto code generation. But it may be worthwhile to manually fix it while we come up with a vtproto fork / PR. The downside is that for every new proto change, we'll have to cherrypick the changes line by line to keep these fixes.

benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                            │ bench-out/vtproto-fix-before │     bench-out/vtproto-fix-after     │
                            │            sec/op            │    sec/op     vs base               │
AggregateCombinedMetrics-16                   3.562µ ±  6%   3.397µ ±  3%        ~ (p=0.180 n=6)
AggregateBatchSerial-16                       18.75µ ± 15%   17.37µ ± 10%   -7.36% (p=0.026 n=6)
AggregateBatchParallel-16                     19.72µ ±  5%   18.84µ ±  2%        ~ (p=0.065 n=6)
CombinedMetricsEncoding-16                    8.340µ ±  4%   5.912µ ±  5%  -29.11% (p=0.002 n=6)
CombinedMetricsDecoding-16                    4.297µ ±  3%   4.257µ ±  6%        ~ (p=0.310 n=6)
CombinedMetricsToBatch-16                     417.7µ ±  3%   417.7µ ±  3%        ~ (p=0.818 n=6)
EventToCombinedMetrics-16                     1.026µ ±  6%   1.024µ ±  2%        ~ (p=0.418 n=6)
geomean                                       11.06µ         10.26µ         -7.22%

                            │ bench-out/vtproto-fix-before │     bench-out/vtproto-fix-after     │
                            │             B/op             │     B/op      vs base               │
AggregateCombinedMetrics-16                   3.619Ki ± 3%   3.472Ki ± 5%   -4.07% (p=0.002 n=6)
AggregateBatchSerial-16                       22.77Ki ± 1%   22.18Ki ± 0%   -2.58% (p=0.002 n=6)
AggregateBatchParallel-16                     22.64Ki ± 1%   22.03Ki ± 1%   -2.73% (p=0.002 n=6)
CombinedMetricsEncoding-16                     2624.0 ± 0%     576.0 ± 0%  -78.05% (p=0.002 n=6)
CombinedMetricsDecoding-16                    10.01Ki ± 0%   10.01Ki ± 0%        ~ (p=1.000 n=6)
geomean                                       8.630Ki        6.252Ki       -27.55%

                            │ bench-out/vtproto-fix-before │     bench-out/vtproto-fix-after     │
                            │          allocs/op           │ allocs/op   vs base                 │
AggregateCombinedMetrics-16                     41.00 ± 2%   34.00 ± 3%  -17.07% (p=0.002 n=6)
AggregateBatchSerial-16                         183.0 ± 1%   159.0 ± 0%  -13.11% (p=0.002 n=6)
AggregateBatchParallel-16                       183.0 ± 0%   159.0 ± 1%  -13.11% (p=0.002 n=6)
CombinedMetricsEncoding-16                      77.00 ± 0%   45.00 ± 0%  -41.56% (p=0.002 n=6)
CombinedMetricsDecoding-16                      40.00 ± 0%   40.00 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                         84.19        68.85       -18.22%
¹ all samples are equal
```