### PR TITLE
Use vtproto fork to fix pooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint: tools/go.mod
 
 .PHONY: clean
 clean:
-	rm -fr bin
+	rm -fr bin build
 
 .PHONY: test
 test: go.mod

--- a/aggregationpb/aggregation_vtproto.pb.go
+++ b/aggregationpb/aggregation_vtproto.pb.go
@@ -1352,13 +1352,16 @@ var vtprotoPool_CombinedMetrics = sync.Pool{
 }
 
 func (m *CombinedMetrics) ResetVT() {
-	for _, mm := range m.ServiceMetrics {
-		mm.ResetVT()
+	for k, mm := range m.ServiceMetrics {
+		mm.ReturnToVTPool()
+		m.ServiceMetrics[k] = nil
 	}
+	f0 := m.ServiceMetrics[:0]
 	m.OverflowServices.ReturnToVTPool()
-	f0 := m.OverflowServiceInstancesEstimator[:0]
+	f1 := m.OverflowServiceInstancesEstimator[:0]
 	m.Reset()
-	m.OverflowServiceInstancesEstimator = f0
+	m.ServiceMetrics = f0
+	m.OverflowServiceInstancesEstimator = f1
 }
 func (m *CombinedMetrics) ReturnToVTPool() {
 	if m != nil {
@@ -1419,11 +1422,14 @@ var vtprotoPool_ServiceMetrics = sync.Pool{
 }
 
 func (m *ServiceMetrics) ResetVT() {
-	for _, mm := range m.ServiceInstanceMetrics {
-		mm.ResetVT()
+	for k, mm := range m.ServiceInstanceMetrics {
+		mm.ReturnToVTPool()
+		m.ServiceInstanceMetrics[k] = nil
 	}
+	f0 := m.ServiceInstanceMetrics[:0]
 	m.OverflowGroups.ReturnToVTPool()
 	m.Reset()
+	m.ServiceInstanceMetrics = f0
 }
 func (m *ServiceMetrics) ReturnToVTPool() {
 	if m != nil {
@@ -1463,16 +1469,25 @@ var vtprotoPool_ServiceInstanceMetrics = sync.Pool{
 }
 
 func (m *ServiceInstanceMetrics) ResetVT() {
-	for _, mm := range m.TransactionMetrics {
-		mm.ResetVT()
+	for k, mm := range m.TransactionMetrics {
+		mm.ReturnToVTPool()
+		m.TransactionMetrics[k] = nil
 	}
-	for _, mm := range m.ServiceTransactionMetrics {
-		mm.ResetVT()
+	f0 := m.TransactionMetrics[:0]
+	for k, mm := range m.ServiceTransactionMetrics {
+		mm.ReturnToVTPool()
+		m.ServiceTransactionMetrics[k] = nil
 	}
-	for _, mm := range m.SpanMetrics {
-		mm.ResetVT()
+	f1 := m.ServiceTransactionMetrics[:0]
+	for k, mm := range m.SpanMetrics {
+		mm.ReturnToVTPool()
+		m.SpanMetrics[k] = nil
 	}
+	f2 := m.SpanMetrics[:0]
 	m.Reset()
+	m.TransactionMetrics = f0
+	m.ServiceTransactionMetrics = f1
+	m.SpanMetrics = f2
 }
 func (m *ServiceInstanceMetrics) ReturnToVTPool() {
 	if m != nil {

--- a/aggregationpb/labels_vtproto.pb.go
+++ b/aggregationpb/labels_vtproto.pb.go
@@ -201,13 +201,19 @@ var vtprotoPool_GlobalLabels = sync.Pool{
 }
 
 func (m *GlobalLabels) ResetVT() {
-	for _, mm := range m.Labels {
-		mm.ResetVT()
+	for k, mm := range m.Labels {
+		mm.ReturnToVTPool()
+		m.Labels[k] = nil
 	}
-	for _, mm := range m.NumericLabels {
-		mm.ResetVT()
+	f0 := m.Labels[:0]
+	for k, mm := range m.NumericLabels {
+		mm.ReturnToVTPool()
+		m.NumericLabels[k] = nil
 	}
+	f1 := m.NumericLabels[:0]
 	m.Reset()
+	m.Labels = f0
+	m.NumericLabels = f1
 }
 func (m *GlobalLabels) ReturnToVTPool() {
 	if m != nil {

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -16,3 +16,5 @@ require (
 	golang.org/x/sys v0.8.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+
+replace github.com/planetscale/vtprotobuf => github.com/carsonip/vtprotobuf v0.0.0-20230711135402-2cf3150fde0e

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,13 +1,13 @@
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/carsonip/vtprotobuf v0.0.0-20230711135402-2cf3150fde0e h1:lcgWGj99s7E/NzQTsyKtFN+VkHPmYAA8U73Y9fBFZdU=
+github.com/carsonip/vtprotobuf v0.0.0-20230711135402-2cf3150fde0e/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0PbwYYpP5P5VhTks=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-licenser v0.4.1 h1:1xDURsc8pL5zYT9R29425J3vkHdt4RT5TNEMeRN48x4=
 github.com/elastic/go-licenser v0.4.1/go.mod h1:V56wHMpmdURfibNBggaSBfqgPxyT1Tldns1i87iTEvU=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/planetscale/vtprotobuf v0.4.0 h1:NEI+g4woRaAZgeZ3sAvbtyvMBRjIv5kE7EWYQ8m4JwY=
-github.com/planetscale/vtprotobuf v0.4.0/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0PbwYYpP5P5VhTks=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
See #16. Use vtproto fork to generate code that does not have the pooling bug.

The changes to vtproto: https://github.com/planetscale/vtprotobuf/compare/main...carsonip:vtprotobuf:fix-pooling
It fixes our case and generates the right code, but not sure if it breaks any code outside our use case.

benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                            │ bench-out/vtproto-fix-codegen-before │ bench-out/vtproto-fix-codegen-after │
                            │                sec/op                │    sec/op     vs base               │
AggregateCombinedMetrics-16                           3.537µ ±  3%    3.416µ ± 5%        ~ (p=0.240 n=6)
AggregateBatchSerial-16                               18.02µ ±  4%    17.55µ ± 3%   -2.60% (p=0.041 n=6)
AggregateBatchParallel-16                             19.69µ ±  6%    18.90µ ± 6%   -4.01% (p=0.015 n=6)
CombinedMetricsEncoding-16                            8.241µ ±  2%    5.974µ ± 1%  -27.51% (p=0.002 n=6)
CombinedMetricsDecoding-16                            4.268µ ±  1%    4.295µ ± 2%        ~ (p=0.485 n=6)
CombinedMetricsToBatch-16                             426.0µ ±  3%    414.6µ ± 2%   -2.66% (p=0.009 n=6)
EventToCombinedMetrics-16                             1.022µ ± 10%    1.034µ ± 4%        ~ (p=0.513 n=6)
geomean                                               10.98µ          10.32µ        -6.00%

                            │ bench-out/vtproto-fix-codegen-before │ bench-out/vtproto-fix-codegen-after │
                            │                 B/op                 │     B/op      vs base               │
AggregateCombinedMetrics-16                          3.606Ki ± 12%   3.477Ki ± 1%   -3.57% (p=0.002 n=6)
AggregateBatchSerial-16                              22.72Ki ±  1%   22.19Ki ± 1%   -2.34% (p=0.002 n=6)
AggregateBatchParallel-16                            22.64Ki ±  1%   22.29Ki ± 1%   -1.54% (p=0.002 n=6)
CombinedMetricsEncoding-16                            2624.0 ±  0%     576.0 ± 0%  -78.05% (p=0.002 n=6)
CombinedMetricsDecoding-16                           10.01Ki ±  0%   10.01Ki ± 0%        ~ (p=0.182 n=6)
geomean                                              8.620Ki         6.269Ki       -27.27%

                            │ bench-out/vtproto-fix-codegen-before │ bench-out/vtproto-fix-codegen-after │
                            │              allocs/op               │ allocs/op   vs base                 │
AggregateCombinedMetrics-16                             41.00 ± 7%   34.00 ± 3%  -17.07% (p=0.002 n=6)
AggregateBatchSerial-16                                 182.5 ± 1%   159.0 ± 1%  -12.88% (p=0.002 n=6)
AggregateBatchParallel-16                               183.0 ± 0%   159.0 ± 0%  -13.11% (p=0.002 n=6)
CombinedMetricsEncoding-16                              77.00 ± 0%   45.00 ± 0%  -41.56% (p=0.002 n=6)
CombinedMetricsDecoding-16                              40.00 ± 0%   40.00 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                 84.14        68.85       -18.17%
¹ all samples are equal
```