### PR TITLE
Increase time to wait for first harvest

### DIFF
--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -999,7 +999,7 @@ func TestRunStopOrchestration(t *testing.T) {
 		go func() { agg.Run(ctx) }()
 		assert.Eventually(t, func() bool {
 			return firstHarvestDone.Load()
-		}, time.Second, 10*time.Millisecond, "failed while waiting for first harvest")
+		}, 10*time.Second, 10*time.Millisecond, "failed while waiting for first harvest")
 		assert.NoError(t, callAggregateBatch(agg))
 		assert.NoError(t, agg.Stop(ctx))
 		assert.ErrorIs(t, callAggregateBatch(agg), ErrAggregatorStopped)


### PR DESCRIPTION
Attempts fixing a flaky test. The test waits for first harvest to be done, however, the aggregation interval and the wait time are both 1 second which causes flakiness.