### PR TITLE
Performance improvements

### DIFF
--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -474,7 +474,9 @@ func (gl *GlobalLabels) ToProto() *aggregationpb.GlobalLabels {
 
 	// Keys must be sorted to ensure wire formats are deterministically generated and strings are directly comparable
 	// i.e. Protobuf formats are equal if and only if the structs are equal
-	pb.Labels = make([]*aggregationpb.Label, 0, len(gl.Labels))
+	if len(gl.Labels) > cap(pb.Labels) {
+		pb.Labels = make([]*aggregationpb.Label, 0, len(gl.Labels))
+	}
 	for k, v := range gl.Labels {
 		l := aggregationpb.LabelFromVTPool()
 		l.Key = k
@@ -487,7 +489,9 @@ func (gl *GlobalLabels) ToProto() *aggregationpb.GlobalLabels {
 		return pb.Labels[i].Key < pb.Labels[j].Key
 	})
 
-	pb.NumericLabels = make([]*aggregationpb.NumericLabel, 0, len(gl.NumericLabels))
+	if len(gl.NumericLabels) > cap(pb.NumericLabels) {
+		pb.NumericLabels = make([]*aggregationpb.NumericLabel, 0, len(gl.NumericLabels))
+	}
 	for k, v := range gl.NumericLabels {
 		l := aggregationpb.NumericLabelFromVTPool()
 		l.Key = k


### PR DESCRIPTION
- Reuse labels backing array to reduce allocs. Missed in #18 
- Remove tracing for AggregateBatch to reduce allocs

benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                            │ bench-out/optimizations3-before │   bench-out/optimizations3-after   │
                            │             sec/op              │   sec/op     vs base               │
AggregateCombinedMetrics-16                       3.318µ ± 4%   3.409µ ± 4%        ~ (p=0.258 n=6)
AggregateBatchSerial-16                           16.89µ ± 8%   13.57µ ± 5%  -19.65% (p=0.002 n=6)
AggregateBatchParallel-16                         18.13µ ± 4%   14.71µ ± 9%  -18.88% (p=0.002 n=6)
CombinedMetricsEncoding-16                        5.279µ ± 4%   5.276µ ± 4%        ~ (p=0.394 n=6)
CombinedMetricsDecoding-16                        4.351µ ± 3%   4.356µ ± 4%        ~ (p=0.818 n=6)
CombinedMetricsToBatch-16                         425.5µ ± 3%   438.1µ ± 4%   +2.98% (p=0.015 n=6)
EventToCombinedMetrics-16                        1055.0n ± 4%   965.9n ± 4%   -8.45% (p=0.002 n=6)
geomean                                           10.07µ        9.427µ        -6.35%

                            │ bench-out/optimizations3-before │    bench-out/optimizations3-after    │
                            │              B/op               │     B/op      vs base                │
AggregateCombinedMetrics-16                    3.460Ki ± 2%     3.411Ki ± 2%       ~ (p=0.240 n=6)
AggregateBatchSerial-16                        22.02Ki ± 0%     20.15Ki ± 0%  -8.47% (p=0.002 n=6)
AggregateBatchParallel-16                      22.07Ki ± 0%     20.13Ki ± 0%  -8.81% (p=0.002 n=6)
CombinedMetricsEncoding-16                       0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
CombinedMetricsDecoding-16                     10.01Ki ± 0%     10.01Ki ± 0%       ~ (p=1.000 n=6)
geomean                                                     ²                 -3.82%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                            │ bench-out/optimizations3-before │   bench-out/optimizations3-after    │
                            │            allocs/op            │ allocs/op   vs base                 │
AggregateCombinedMetrics-16                      27.00 ± 4%     26.00 ± 4%        ~ (p=0.567 n=6)
AggregateBatchSerial-16                         135.00 ± 0%     94.00 ± 0%  -30.37% (p=0.002 n=6)
AggregateBatchParallel-16                       135.00 ± 1%     94.00 ± 0%  -30.37% (p=0.002 n=6)
CombinedMetricsEncoding-16                       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
CombinedMetricsDecoding-16                       40.00 ± 0%     40.00 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                     ²               -14.13%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```