### PR TITLE
Fix size of combined metrics key

### DIFF
--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -54,7 +54,7 @@ func TestAggregateBatch(t *testing.T) {
 	require.NoError(t, err)
 	mp := metric.NewMeterProvider(metric.WithReader(gatherer))
 
-	cmID := "testid"
+	cmID := "ab01"
 	txnDuration := 100 * time.Millisecond
 	uniqueEventCount := 100 // for each of txns and spans
 	uniqueServices := 10
@@ -585,7 +585,7 @@ func TestAggregateSpanMetrics(t *testing.T) {
 					defaultNumericLabels,
 				)
 				for i := 0; i < count; i++ {
-					err := agg.AggregateBatch(context.Background(), "testid", &modelpb.Batch{span})
+					err := agg.AggregateBatch(context.Background(), "ab01", &modelpb.Batch{span})
 					require.NoError(t, err)
 				}
 			}
@@ -637,7 +637,7 @@ func TestCombinedMetricsKeyOrdered(t *testing.T) {
 	before := CombinedMetricsKey{
 		ProcessingTime: ts.Truncate(time.Minute),
 		Interval:       ivl,
-		ID:             "cm01",
+		ID:             "ab01",
 	}
 	marshaledBufferSize := before.SizeBinary()
 	beforeBytes := make([]byte, marshaledBufferSize)
@@ -651,7 +651,7 @@ func TestCombinedMetricsKeyOrdered(t *testing.T) {
 			// combined metrics ID shouldn't matter. Keep length to be
 			// 5 to ensure it is within expected bounds of the
 			// sized buffer.
-			ID: fmt.Sprintf("cm%02d", rand.Intn(100)),
+			ID: fmt.Sprintf("ab%02d", rand.Intn(100)),
 		}
 		require.NoError(t, after.MarshalBinaryToSizedBuffer(afterBytes))
 		require.NoError(t, before.MarshalBinaryToSizedBuffer(beforeBytes))
@@ -680,7 +680,7 @@ func TestCombinedMetricsKeyOrderedByProjectID(t *testing.T) {
 	keys := make([]CombinedMetricsKey, 0, cmCount*pidCount)
 
 	for i := 0; i < cmCount; i++ {
-		cmID := fmt.Sprintf("cm%05d", i)
+		cmID := fmt.Sprintf("ab%06d", i)
 		for k := 0; k < pidCount; k++ {
 			key := keyTemplate
 			key.PartitionID = uint16(k)
@@ -788,7 +788,7 @@ func TestHarvest(t *testing.T) {
 	})
 	expectedMeasurements := make([]apmmodel.Metrics, 0, cmCount+(cmCount*len(ivls)))
 	for i := 0; i < cmCount; i++ {
-		cmID := fmt.Sprintf("testid%d", i)
+		cmID := fmt.Sprintf("ab0%d", i)
 		require.NoError(t, agg.AggregateBatch(context.Background(), cmID, &batch))
 		expectedMeasurements = append(expectedMeasurements, apmmodel.Metrics{
 			Samples: map[string]apmmodel.Metric{
@@ -894,7 +894,7 @@ func TestAggregateAndHarvest(t *testing.T) {
 		WithAggregationIntervals([]time.Duration{time.Second}),
 	)
 	require.NoError(t, err)
-	require.NoError(t, agg.AggregateBatch(context.Background(), "test", &batch))
+	require.NoError(t, agg.AggregateBatch(context.Background(), "ab01", &batch))
 	require.NoError(t, agg.Stop(context.Background()))
 
 	expected := []*modelpb.APMEvent{
@@ -1030,7 +1030,7 @@ func TestRunStopOrchestration(t *testing.T) {
 	callAggregateBatch := func(agg *Aggregator) error {
 		return agg.AggregateBatch(
 			context.Background(),
-			"testid",
+			"ab01",
 			&modelpb.Batch{
 				&modelpb.APMEvent{
 					Processor: modelpb.TransactionProcessor(),
@@ -1120,7 +1120,7 @@ func BenchmarkAggregateCombinedMetrics(b *testing.B) {
 	cmk := CombinedMetricsKey{
 		Interval:       aggIvl,
 		ProcessingTime: time.Now().Truncate(aggIvl),
-		ID:             "testid",
+		ID:             "ab01",
 	}
 	kvs, err := EventToCombinedMetrics(
 		&modelpb.APMEvent{
@@ -1155,7 +1155,7 @@ func BenchmarkAggregateBatchSerial(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		if err := agg.AggregateBatch(context.Background(), "test", batch); err != nil {
+		if err := agg.AggregateBatch(context.Background(), "ab01", batch); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -1170,7 +1170,7 @@ func BenchmarkAggregateBatchParallel(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if err := agg.AggregateBatch(context.Background(), "test", batch); err != nil {
+			if err := agg.AggregateBatch(context.Background(), "ab01", batch); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -8,11 +8,8 @@ package aggregators
 // fields are properly set.
 
 import (
-	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
-	"fmt"
 	"sort"
 	"time"
 
@@ -23,30 +20,6 @@ import (
 	"github.com/elastic/apm-aggregation/aggregators/internal/timestamppb"
 	"github.com/elastic/apm-data/model/modelpb"
 )
-
-// EncodeToCombinedMetricsKeyID encodes a given string to a byte array
-// of length 16, compatible with the requirements of CombinedMetricsKey.
-func EncodeToCombinedMetricsKeyID(s string) ([16]byte, error) {
-	var b [16]byte
-	decodedLen := hex.DecodedLen(len(s))
-	if decodedLen > len(b) {
-		return b, fmt.Errorf("unexpected ID field, ID must be of max decoded length %d", len(b))
-	}
-	// Add padding to accomodate smaller strings
-	padding := len(b) - decodedLen
-	for i := 0; i < padding; i++ {
-		b[i] = '\x00'
-	}
-	if _, err := hex.Decode(b[padding:], []byte(s)); err != nil {
-		return b, fmt.Errorf("failed to decode ID, ID must be hexadecimal string: %w", err)
-	}
-	return b, nil
-}
-
-// DecodeFromCombinedMetricsKeyID decodes a given byte array to string.
-func DecodeFromCombinedMetricsKeyID(b [16]byte) string {
-	return hex.EncodeToString(bytes.TrimLeft(b[:], "\x00"))
-}
 
 // MarshalBinaryToSizedBuffer will marshal the combined metrics key into
 // its binary representation. The encoded byte slice will be used as a

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -31,9 +31,9 @@ const maxSizeForCombinedMetricsKeyID = 16
 // key in pebbledb. To ensure efficient sorting and time range based
 // query, the first 2 bytes of the encoded slice is the aggregation
 // interval, the next 8 bytes of the encoded slice is the processing time
-// followed by max 32 bytes of combined metrics ID, the last 2 bytes is
-// the partition ID. The binary representation ensures that all entries
-// are ordered by the ID first and then ordered by the partition ID.
+// followed by combined metrics ID, the last 2 bytes is the partition ID.
+// The binary representation ensures that all entries are ordered by the
+// ID first and then ordered by the partition ID.
 func (k *CombinedMetricsKey) MarshalBinaryToSizedBuffer(data []byte) error {
 	ivlSeconds := uint16(k.Interval.Seconds())
 	if len(data) != k.SizeBinary() {

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -57,7 +57,7 @@ func (k *CombinedMetricsKey) MarshalBinaryToSizedBuffer(data []byte) error {
 	binary.BigEndian.PutUint64(data[offset:], uint64(k.ProcessingTime.Unix()))
 	offset += 8
 
-	// Pad if projectID is of smaller length
+	// Pad ID to maxSizeForCombinedMetricsKeyID
 	padding := maxSizeForCombinedMetricsKeyID - len(decodedID)
 	for i := 0; i < padding; i++ {
 		data[offset+i] = '\x00'

--- a/aggregators/config.go
+++ b/aggregators/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	Partitioner            Partitioner
 	AggregationIntervals   []time.Duration
 	HarvestDelay           time.Duration
-	CombinedMetricsIDToKVs func(string) []attribute.KeyValue
+	CombinedMetricsIDToKVs func([16]byte) []attribute.KeyValue
 	Meter                  metric.Meter
 	Tracer                 trace.Tracer
 	Logger                 *zap.Logger
@@ -151,7 +151,7 @@ func WithTracer(tracer trace.Tracer) Option {
 
 // WithCombinedMetricsIDToKVs defines a function that converts a combined
 // metrics ID to zero or more attribute.KeyValue for telemetry.
-func WithCombinedMetricsIDToKVs(f func(string) []attribute.KeyValue) Option {
+func WithCombinedMetricsIDToKVs(f func([16]byte) []attribute.KeyValue) Option {
 	return func(c Config) Config {
 		c.CombinedMetricsIDToKVs = f
 		return c
@@ -174,7 +174,7 @@ func defaultCfg() Config {
 		AggregationIntervals:   []time.Duration{time.Minute},
 		Meter:                  otel.Meter(instrumentationName),
 		Tracer:                 otel.Tracer(instrumentationName),
-		CombinedMetricsIDToKVs: func(_ string) []attribute.KeyValue { return nil },
+		CombinedMetricsIDToKVs: func(_ [16]byte) []attribute.KeyValue { return nil },
 		Logger:                 zap.Must(zap.NewDevelopment()),
 	}
 }

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -44,10 +44,12 @@ func TestEventToCombinedMetrics(t *testing.T) {
 			Type:                "testtyp",
 		},
 	}
+	cmkID, err := EncodeToCombinedMetricsKeyID("ab01")
+	require.NoError(t, err)
 	cmk := CombinedMetricsKey{
 		Interval:       time.Minute,
 		ProcessingTime: time.Now().Truncate(time.Minute),
-		ID:             "test-id",
+		ID:             cmkID,
 	}
 	kvs, err := EventToCombinedMetrics(event, cmk, NewHashPartitioner(1))
 	require.NoError(t, err)
@@ -252,10 +254,12 @@ func BenchmarkEventToCombinedMetrics(b *testing.B) {
 			Type:                "testtyp",
 		},
 	}
+	cmkID, err := EncodeToCombinedMetricsKeyID("ab01")
+	require.NoError(b, err)
 	cmk := CombinedMetricsKey{
 		Interval:       time.Minute,
 		ProcessingTime: time.Now().Truncate(time.Minute),
-		ID:             "testid",
+		ID:             cmkID,
 	}
 	partitioner := NewHashPartitioner(1)
 	b.ResetTimer()

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -44,12 +44,10 @@ func TestEventToCombinedMetrics(t *testing.T) {
 			Type:                "testtyp",
 		},
 	}
-	cmkID, err := EncodeToCombinedMetricsKeyID("ab01")
-	require.NoError(t, err)
 	cmk := CombinedMetricsKey{
 		Interval:       time.Minute,
 		ProcessingTime: time.Now().Truncate(time.Minute),
-		ID:             cmkID,
+		ID:             EncodeToCombinedMetricsKeyID(t, "ab01"),
 	}
 	kvs, err := EventToCombinedMetrics(event, cmk, NewHashPartitioner(1))
 	require.NoError(t, err)
@@ -254,12 +252,10 @@ func BenchmarkEventToCombinedMetrics(b *testing.B) {
 			Type:                "testtyp",
 		},
 	}
-	cmkID, err := EncodeToCombinedMetricsKeyID("ab01")
-	require.NoError(b, err)
 	cmk := CombinedMetricsKey{
 		Interval:       time.Minute,
 		ProcessingTime: time.Now().Truncate(time.Minute),
-		ID:             cmkID,
+		ID:             EncodeToCombinedMetricsKeyID(b, "ab01"),
 	}
 	partitioner := NewHashPartitioner(1)
 	b.ResetTimer()

--- a/aggregators/models.go
+++ b/aggregators/models.go
@@ -115,7 +115,7 @@ type CombinedMetricsKey struct {
 	Interval       time.Duration
 	ProcessingTime time.Time
 	PartitionID    uint16
-	ID             string
+	ID             [16]byte
 }
 
 // CombinedMetrics models the value to store the data in LSM tree.


### PR DESCRIPTION
Updates `CombinedMetricsKey.ID` and the aggregation interfaces to use `[16]byte` instead of `string`. This also fixes the size of binary encoded `CombinedMetricsKey` which will allow us to do efficient pooling for the buffer used to encode `CombinedMetricsKey`.