### PR TITLE
Use proto models directly for AggregateBatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ gen-proto: $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_VTPROTO) $(PROTOC)
 	$(eval PROTOC_VT_STRUCTS := $(shell for s in $(STRUCTS); do echo --go-vtproto_opt=pool=./aggregationpb.$$s ;done))
 	$(PROTOC) -I . --go_out=$(PROTOC_OUT) --plugin protoc-gen-go="$(PROTOC_GEN_GO)" \
 	--go-vtproto_out=$(PROTOC_OUT) --plugin protoc-gen-go-vtproto="$(PROTOC_GEN_GO_VTPROTO)" \
-	--go-vtproto_opt=features=marshal+unmarshal+size+pool \
+	--go-vtproto_opt=features=marshal+unmarshal+size+pool+clone \
 	$(PROTOC_VT_STRUCTS) \
 	$(wildcard proto/*.proto)
 	$(MAKE) fmt

--- a/aggregationpb/aggregation_vtproto.pb.go
+++ b/aggregationpb/aggregation_vtproto.pb.go
@@ -16,6 +16,7 @@ import (
 	bits "math/bits"
 	sync "sync"
 
+	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
@@ -25,6 +26,470 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+func (m *CombinedMetrics) CloneVT() *CombinedMetrics {
+	if m == nil {
+		return (*CombinedMetrics)(nil)
+	}
+	r := &CombinedMetrics{
+		OverflowServices:       m.OverflowServices.CloneVT(),
+		EventsTotal:            m.EventsTotal,
+		YoungestEventTimestamp: m.YoungestEventTimestamp,
+	}
+	if rhs := m.ServiceMetrics; rhs != nil {
+		tmpContainer := make([]*KeyedServiceMetrics, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.ServiceMetrics = tmpContainer
+	}
+	if rhs := m.OverflowServiceInstancesEstimator; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OverflowServiceInstancesEstimator = tmpBytes
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CombinedMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *KeyedServiceMetrics) CloneVT() *KeyedServiceMetrics {
+	if m == nil {
+		return (*KeyedServiceMetrics)(nil)
+	}
+	r := &KeyedServiceMetrics{
+		Key:     m.Key.CloneVT(),
+		Metrics: m.Metrics.CloneVT(),
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *KeyedServiceMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ServiceAggregationKey) CloneVT() *ServiceAggregationKey {
+	if m == nil {
+		return (*ServiceAggregationKey)(nil)
+	}
+	r := &ServiceAggregationKey{
+		Timestamp:           m.Timestamp,
+		ServiceName:         m.ServiceName,
+		ServiceEnvironment:  m.ServiceEnvironment,
+		ServiceLanguageName: m.ServiceLanguageName,
+		AgentName:           m.AgentName,
+	}
+	if rhs := m.GlobalLabelsStr; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.GlobalLabelsStr = tmpBytes
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ServiceAggregationKey) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ServiceMetrics) CloneVT() *ServiceMetrics {
+	if m == nil {
+		return (*ServiceMetrics)(nil)
+	}
+	r := &ServiceMetrics{
+		OverflowGroups: m.OverflowGroups.CloneVT(),
+	}
+	if rhs := m.ServiceInstanceMetrics; rhs != nil {
+		tmpContainer := make([]*KeyedServiceInstanceMetrics, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.ServiceInstanceMetrics = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ServiceMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ServiceInstanceAggregationKey) CloneVT() *ServiceInstanceAggregationKey {
+	if m == nil {
+		return (*ServiceInstanceAggregationKey)(nil)
+	}
+	r := &ServiceInstanceAggregationKey{}
+	if rhs := m.GlobalLabelsStr; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.GlobalLabelsStr = tmpBytes
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ServiceInstanceAggregationKey) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ServiceInstanceMetrics) CloneVT() *ServiceInstanceMetrics {
+	if m == nil {
+		return (*ServiceInstanceMetrics)(nil)
+	}
+	r := &ServiceInstanceMetrics{}
+	if rhs := m.TransactionMetrics; rhs != nil {
+		tmpContainer := make([]*KeyedTransactionMetrics, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.TransactionMetrics = tmpContainer
+	}
+	if rhs := m.ServiceTransactionMetrics; rhs != nil {
+		tmpContainer := make([]*KeyedServiceTransactionMetrics, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.ServiceTransactionMetrics = tmpContainer
+	}
+	if rhs := m.SpanMetrics; rhs != nil {
+		tmpContainer := make([]*KeyedSpanMetrics, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.SpanMetrics = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ServiceInstanceMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *KeyedServiceInstanceMetrics) CloneVT() *KeyedServiceInstanceMetrics {
+	if m == nil {
+		return (*KeyedServiceInstanceMetrics)(nil)
+	}
+	r := &KeyedServiceInstanceMetrics{
+		Key:     m.Key.CloneVT(),
+		Metrics: m.Metrics.CloneVT(),
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *KeyedServiceInstanceMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *KeyedTransactionMetrics) CloneVT() *KeyedTransactionMetrics {
+	if m == nil {
+		return (*KeyedTransactionMetrics)(nil)
+	}
+	r := &KeyedTransactionMetrics{
+		Key:     m.Key.CloneVT(),
+		Metrics: m.Metrics.CloneVT(),
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *KeyedTransactionMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TransactionAggregationKey) CloneVT() *TransactionAggregationKey {
+	if m == nil {
+		return (*TransactionAggregationKey)(nil)
+	}
+	r := &TransactionAggregationKey{
+		TraceRoot:              m.TraceRoot,
+		ContainerId:            m.ContainerId,
+		KubernetesPodName:      m.KubernetesPodName,
+		ServiceVersion:         m.ServiceVersion,
+		ServiceNodeName:        m.ServiceNodeName,
+		ServiceRuntimeName:     m.ServiceRuntimeName,
+		ServiceRuntimeVersion:  m.ServiceRuntimeVersion,
+		ServiceLanguageVersion: m.ServiceLanguageVersion,
+		HostHostname:           m.HostHostname,
+		HostName:               m.HostName,
+		HostOsPlatform:         m.HostOsPlatform,
+		EventOutcome:           m.EventOutcome,
+		TransactionName:        m.TransactionName,
+		TransactionType:        m.TransactionType,
+		TransactionResult:      m.TransactionResult,
+		FaasColdstart:          m.FaasColdstart,
+		FaasId:                 m.FaasId,
+		FaasName:               m.FaasName,
+		FaasVersion:            m.FaasVersion,
+		FaasTriggerType:        m.FaasTriggerType,
+		CloudProvider:          m.CloudProvider,
+		CloudRegion:            m.CloudRegion,
+		CloudAvailabilityZone:  m.CloudAvailabilityZone,
+		CloudServiceName:       m.CloudServiceName,
+		CloudAccountId:         m.CloudAccountId,
+		CloudAccountName:       m.CloudAccountName,
+		CloudMachineType:       m.CloudMachineType,
+		CloudProjectId:         m.CloudProjectId,
+		CloudProjectName:       m.CloudProjectName,
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *TransactionAggregationKey) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *TransactionMetrics) CloneVT() *TransactionMetrics {
+	if m == nil {
+		return (*TransactionMetrics)(nil)
+	}
+	r := &TransactionMetrics{
+		Histogram: m.Histogram.CloneVT(),
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *TransactionMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *KeyedServiceTransactionMetrics) CloneVT() *KeyedServiceTransactionMetrics {
+	if m == nil {
+		return (*KeyedServiceTransactionMetrics)(nil)
+	}
+	r := &KeyedServiceTransactionMetrics{
+		Key:     m.Key.CloneVT(),
+		Metrics: m.Metrics.CloneVT(),
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *KeyedServiceTransactionMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ServiceTransactionAggregationKey) CloneVT() *ServiceTransactionAggregationKey {
+	if m == nil {
+		return (*ServiceTransactionAggregationKey)(nil)
+	}
+	r := &ServiceTransactionAggregationKey{
+		TransactionType: m.TransactionType,
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ServiceTransactionAggregationKey) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ServiceTransactionMetrics) CloneVT() *ServiceTransactionMetrics {
+	if m == nil {
+		return (*ServiceTransactionMetrics)(nil)
+	}
+	r := &ServiceTransactionMetrics{
+		Histogram:    m.Histogram.CloneVT(),
+		FailureCount: m.FailureCount,
+		SuccessCount: m.SuccessCount,
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ServiceTransactionMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *KeyedSpanMetrics) CloneVT() *KeyedSpanMetrics {
+	if m == nil {
+		return (*KeyedSpanMetrics)(nil)
+	}
+	r := &KeyedSpanMetrics{
+		Key:     m.Key.CloneVT(),
+		Metrics: m.Metrics.CloneVT(),
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *KeyedSpanMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *SpanAggregationKey) CloneVT() *SpanAggregationKey {
+	if m == nil {
+		return (*SpanAggregationKey)(nil)
+	}
+	r := &SpanAggregationKey{
+		SpanName:   m.SpanName,
+		Outcome:    m.Outcome,
+		TargetType: m.TargetType,
+		TargetName: m.TargetName,
+		Resource:   m.Resource,
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *SpanAggregationKey) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *SpanMetrics) CloneVT() *SpanMetrics {
+	if m == nil {
+		return (*SpanMetrics)(nil)
+	}
+	r := &SpanMetrics{
+		Count: m.Count,
+		Sum:   m.Sum,
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *SpanMetrics) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *CountValue) CloneVT() *CountValue {
+	if m == nil {
+		return (*CountValue)(nil)
+	}
+	r := &CountValue{
+		Count: m.Count,
+		Value: m.Value,
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CountValue) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *HDRHistogram) CloneVT() *HDRHistogram {
+	if m == nil {
+		return (*HDRHistogram)(nil)
+	}
+	r := &HDRHistogram{
+		LowestTrackableValue:  m.LowestTrackableValue,
+		HighestTrackableValue: m.HighestTrackableValue,
+		SignificantFigures:    m.SignificantFigures,
+	}
+	if rhs := m.Counts; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Counts = tmpContainer
+	}
+	if rhs := m.Buckets; rhs != nil {
+		tmpContainer := make([]int32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Buckets = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *HDRHistogram) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Overflow) CloneVT() *Overflow {
+	if m == nil {
+		return (*Overflow)(nil)
+	}
+	r := &Overflow{
+		OverflowTransactions:        m.OverflowTransactions.CloneVT(),
+		OverflowServiceTransactions: m.OverflowServiceTransactions.CloneVT(),
+		OverflowSpans:               m.OverflowSpans.CloneVT(),
+	}
+	if rhs := m.OverflowTransactionsEstimator; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OverflowTransactionsEstimator = tmpBytes
+	}
+	if rhs := m.OverflowServiceTransactionsEstimator; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OverflowServiceTransactionsEstimator = tmpBytes
+	}
+	if rhs := m.OverflowSpansEstimator; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.OverflowSpansEstimator = tmpBytes
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *Overflow) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
 
 func (m *CombinedMetrics) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {

--- a/aggregationpb/labels_vtproto.pb.go
+++ b/aggregationpb/labels_vtproto.pb.go
@@ -15,6 +15,7 @@ import (
 	math "math"
 	sync "sync"
 
+	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
@@ -24,6 +25,84 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+func (m *GlobalLabels) CloneVT() *GlobalLabels {
+	if m == nil {
+		return (*GlobalLabels)(nil)
+	}
+	r := &GlobalLabels{}
+	if rhs := m.Labels; rhs != nil {
+		tmpContainer := make([]*Label, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Labels = tmpContainer
+	}
+	if rhs := m.NumericLabels; rhs != nil {
+		tmpContainer := make([]*NumericLabel, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.NumericLabels = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GlobalLabels) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *Label) CloneVT() *Label {
+	if m == nil {
+		return (*Label)(nil)
+	}
+	r := &Label{
+		Key:   m.Key,
+		Value: m.Value,
+	}
+	if rhs := m.Values; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Values = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *Label) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *NumericLabel) CloneVT() *NumericLabel {
+	if m == nil {
+		return (*NumericLabel)(nil)
+	}
+	r := &NumericLabel{
+		Key:   m.Key,
+		Value: m.Value,
+	}
+	if rhs := m.Values; rhs != nil {
+		tmpContainer := make([]float64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Values = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *NumericLabel) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
 
 func (m *GlobalLabels) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -20,67 +20,209 @@ import (
 
 	"github.com/elastic/apm-data/model/modelpb"
 
+	"github.com/elastic/apm-aggregation/aggregationpb"
 	"github.com/elastic/apm-aggregation/aggregators/internal/hdrhistogram"
 )
 
 func TestEventToCombinedMetrics(t *testing.T) {
 	ts := time.Now().UTC()
 	receivedTS := ts.Add(time.Second)
-	event := &modelpb.APMEvent{
+	baseEvent := &modelpb.APMEvent{
 		Timestamp: timestamppb.New(ts),
 		ParentId:  "nonroot",
-		Service: &modelpb.Service{
-			Name: "test",
-		},
+		Service:   &modelpb.Service{Name: "test"},
 		Event: &modelpb.Event{
 			Duration: durationpb.New(time.Second),
 			Outcome:  "success",
 			Received: timestamppb.New(receivedTS),
 		},
-		Transaction: &modelpb.Transaction{
-			RepresentativeCount: 1,
-			Name:                "testtxn",
-			Type:                "testtyp",
-		},
 	}
-	cmk := CombinedMetricsKey{
-		Interval:       time.Minute,
-		ProcessingTime: time.Now().Truncate(time.Minute),
-		ID:             EncodeToCombinedMetricsKeyID(t, "ab01"),
+	for _, tc := range []struct {
+		name        string
+		input       func() *modelpb.APMEvent
+		partitioner Partitioner
+		expected    func() []*aggregationpb.CombinedMetrics
+	}{
+		{
+			name: "with-zero-rep-count-txn",
+			input: func() *modelpb.APMEvent {
+				event := baseEvent.CloneVT()
+				event.Transaction = &modelpb.Transaction{
+					Name:                "testtxn",
+					Type:                "testtyp",
+					RepresentativeCount: 0,
+				}
+				return event
+			},
+			partitioner: NewHashPartitioner(1),
+			expected: func() []*aggregationpb.CombinedMetrics {
+				return nil
+			},
+		},
+		{
+			name: "with-good-txn",
+			input: func() *modelpb.APMEvent {
+				event := baseEvent.CloneVT()
+				event.Transaction = &modelpb.Transaction{
+					Name:                "testtxn",
+					Type:                "testtyp",
+					RepresentativeCount: 1,
+				}
+				return event
+			},
+			partitioner: NewHashPartitioner(1),
+			expected: func() []*aggregationpb.CombinedMetrics {
+				return []*aggregationpb.CombinedMetrics{
+					(*CombinedMetrics)(createTestCombinedMetrics(
+						withEventsTotal(1),
+						withYoungestEventTimestamp(receivedTS),
+					).addTransaction(
+						ts.Truncate(time.Minute), "test", "",
+						testTransaction{
+							txnName:      "testtxn",
+							txnType:      "testtyp",
+							eventOutcome: "success",
+							count:        1,
+						},
+					).addServiceTransaction(
+						ts.Truncate(time.Minute), "test", "",
+						testServiceTransaction{
+							txnType: "testtyp",
+							count:   1,
+						},
+					)).ToProto(),
+				}
+			},
+		},
+		{
+			name: "with-zero-rep-count-span",
+			input: func() *modelpb.APMEvent {
+				event := baseEvent.CloneVT()
+				event.Span = &modelpb.Span{
+					Name:                "testspan",
+					Type:                "testtyp",
+					RepresentativeCount: 0,
+				}
+				return event
+			},
+			partitioner: NewHashPartitioner(1),
+			expected: func() []*aggregationpb.CombinedMetrics {
+				return nil
+			},
+		},
+		{
+			name: "with-no-exit-span",
+			input: func() *modelpb.APMEvent {
+				event := baseEvent.CloneVT()
+				event.Span = &modelpb.Span{
+					Name:                "testspan",
+					Type:                "testtyp",
+					RepresentativeCount: 1,
+				}
+				return event
+			},
+			partitioner: NewHashPartitioner(1),
+			expected: func() []*aggregationpb.CombinedMetrics {
+				return nil
+			},
+		},
+		{
+			name: "with-good-span-dest-svc",
+			input: func() *modelpb.APMEvent {
+				event := baseEvent.CloneVT()
+				event.Span = &modelpb.Span{
+					Name:                "testspan",
+					Type:                "testtyp",
+					RepresentativeCount: 1,
+				}
+				event.Service.Target = &modelpb.ServiceTarget{
+					Name: "psql",
+					Type: "db",
+				}
+				// Current test structs are hardcoded to use 1ns for spans
+				event.Event.Duration = durationpb.New(time.Nanosecond)
+				return event
+			},
+			partitioner: NewHashPartitioner(1),
+			expected: func() []*aggregationpb.CombinedMetrics {
+				return []*aggregationpb.CombinedMetrics{
+					(*CombinedMetrics)(createTestCombinedMetrics(
+						withEventsTotal(1),
+						withYoungestEventTimestamp(receivedTS),
+					).addSpan(
+						ts.Truncate(time.Minute), "test", "",
+						testSpan{
+							spanName:   "testspan",
+							targetName: "psql",
+							targetType: "db",
+							outcome:    "success",
+							count:      1,
+						},
+					)).ToProto(),
+				}
+			},
+		},
+		{
+			name: "with-good-span-svc-target",
+			input: func() *modelpb.APMEvent {
+				event := baseEvent.CloneVT()
+				event.Span = &modelpb.Span{
+					Name:                "testspan",
+					Type:                "testtyp",
+					RepresentativeCount: 1,
+					DestinationService: &modelpb.DestinationService{
+						Resource: "db",
+					},
+				}
+				// Current test structs are hardcoded to use 1ns for spans
+				event.Event.Duration = durationpb.New(time.Nanosecond)
+				return event
+			},
+			partitioner: NewHashPartitioner(1),
+			expected: func() []*aggregationpb.CombinedMetrics {
+				return []*aggregationpb.CombinedMetrics{
+					(*CombinedMetrics)(createTestCombinedMetrics(
+						withEventsTotal(1),
+						withYoungestEventTimestamp(receivedTS),
+					).addSpan(
+						ts.Truncate(time.Minute), "test", "",
+						testSpan{
+							spanName:            "testspan",
+							destinationResource: "db",
+							outcome:             "success",
+							count:               1,
+						},
+					)).ToProto(),
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmk := CombinedMetricsKey{
+				Interval:       time.Minute,
+				ProcessingTime: time.Now().Truncate(time.Minute),
+				ID:             EncodeToCombinedMetricsKeyID(t, "ab01"),
+			}
+			var actual []*aggregationpb.CombinedMetrics
+			collector := func(
+				_ CombinedMetricsKey,
+				m *aggregationpb.CombinedMetrics,
+			) error {
+				actual = append(actual, m.CloneVT())
+				return nil
+			}
+			err := EventToCombinedMetrics(tc.input(), cmk, tc.partitioner, collector)
+			require.NoError(t, err)
+			assert.Empty(t, cmp.Diff(
+				tc.expected(), actual,
+				cmp.Comparer(func(a, b hdrhistogram.HybridCountsRep) bool {
+					return a.Equal(&b)
+				}),
+				protocmp.Transform(),
+				protocmp.IgnoreEmptyMessages(),
+			))
+		})
 	}
-	kvs, err := EventToCombinedMetrics(event, cmk, NewHashPartitioner(1))
-	require.NoError(t, err)
-	expected := make(map[CombinedMetricsKey]*CombinedMetrics)
-	expected[cmk] = (*CombinedMetrics)(createTestCombinedMetrics(
-		withEventsTotal(1),
-		withYoungestEventTimestamp(receivedTS),
-	).addTransaction(
-		ts.Truncate(time.Minute),
-		event.Service.Name,
-		"",
-		testTransaction{
-			txnName:      event.Transaction.Name,
-			txnType:      event.Transaction.Type,
-			eventOutcome: event.Event.Outcome,
-			count:        1,
-		},
-	).addServiceTransaction(
-		ts.Truncate(time.Minute),
-		event.Service.Name,
-		"",
-		testServiceTransaction{
-			txnType: event.Transaction.Type,
-			count:   1,
-		},
-	))
-	assert.Empty(t, cmp.Diff(
-		expected, kvs,
-		cmpopts.EquateEmpty(),
-		cmp.Comparer(func(a, b hdrhistogram.HybridCountsRep) bool {
-			return a.Equal(&b)
-		}),
-		cmp.AllowUnexported(CombinedMetrics{}),
-	))
 }
 
 func TestCombinedMetricsToBatch(t *testing.T) {
@@ -187,8 +329,6 @@ func TestCombinedMetricsToBatch(t *testing.T) {
 			assert.Empty(t, cmp.Diff(
 				tc.expectedEvents, *b,
 				cmpopts.IgnoreTypes(netip.Addr{}),
-				cmpopts.EquateEmpty(),
-				protocmp.Transform(),
 				cmpopts.SortSlices(func(e1, e2 *modelpb.APMEvent) bool {
 					m1Name := e1.GetMetricset().GetName()
 					m2Name := e2.GetMetricset().GetName()
@@ -204,6 +344,7 @@ func TestCombinedMetricsToBatch(t *testing.T) {
 
 					return e1.GetService().GetEnvironment() < e2.GetService().GetEnvironment()
 				}),
+				protocmp.Transform(),
 			))
 		})
 	}
@@ -256,9 +397,12 @@ func BenchmarkEventToCombinedMetrics(b *testing.B) {
 		ID:             EncodeToCombinedMetricsKeyID(b, "ab01"),
 	}
 	partitioner := NewHashPartitioner(1)
+	noop := func(_ CombinedMetricsKey, _ *aggregationpb.CombinedMetrics) error {
+		return nil
+	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := EventToCombinedMetrics(event, cmk, partitioner)
+		err := EventToCombinedMetrics(event, cmk, partitioner, noop)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/aggregators/hasher.go
+++ b/aggregators/hasher.go
@@ -4,20 +4,136 @@
 
 package aggregators
 
-import "github.com/cespare/xxhash/v2"
+import (
+	"encoding/binary"
 
+	"github.com/cespare/xxhash/v2"
+
+	"github.com/elastic/apm-aggregation/aggregationpb"
+)
+
+// HashableFunc is a function type that implements Hashable.
+type HashableFunc func(xxhash.Digest) xxhash.Digest
+
+// Hash calls HashableFunc function.
+func (f HashableFunc) Hash(d xxhash.Digest) xxhash.Digest {
+	return f(d)
+}
+
+// Hashable represents the hash function interface implemented by aggregation models.
 type Hashable interface {
 	Hash(xxhash.Digest) xxhash.Digest
 }
 
+// Hasher contains a safe to copy digest.
 type Hasher struct {
 	digest xxhash.Digest // xxhash.Digest does not contain pointers and is safe to copy
 }
 
+// Chain allows chaining hash functions for Hashable interfaces.
 func (h Hasher) Chain(hashable Hashable) Hasher {
 	return Hasher{digest: hashable.Hash(h.digest)}
 }
 
+// Sum returns the hash for all the chained interfaces.
 func (h Hasher) Sum() uint64 {
 	return h.digest.Sum64()
+}
+
+func serviceKeyHasher(
+	k *aggregationpb.ServiceAggregationKey,
+) Hashable {
+	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], k.Timestamp)
+		h.Write(buf[:])
+
+		h.WriteString(k.ServiceName)
+		h.WriteString(k.ServiceEnvironment)
+		h.WriteString(k.ServiceLanguageName)
+		h.WriteString(k.AgentName)
+		return h
+	})
+}
+
+func serviceInstanceKeyHasher(
+	k *aggregationpb.ServiceInstanceAggregationKey,
+) Hashable {
+	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
+		h.Write(k.GlobalLabelsStr)
+		return h
+	})
+}
+
+func serviceTransactionKeyHasher(
+	k *aggregationpb.ServiceTransactionAggregationKey,
+) Hashable {
+	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
+		h.WriteString(k.TransactionType)
+		return h
+	})
+}
+
+func spanKeyHasher(
+	k *aggregationpb.SpanAggregationKey,
+) Hashable {
+	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
+		h.WriteString(k.SpanName)
+		h.WriteString(k.Outcome)
+
+		h.WriteString(k.TargetType)
+		h.WriteString(k.TargetName)
+
+		h.WriteString(k.Resource)
+		return h
+	})
+}
+
+func transactionKeyHasher(
+	k *aggregationpb.TransactionAggregationKey,
+) Hashable {
+	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
+		if k.TraceRoot {
+			h.WriteString("1")
+		}
+
+		h.WriteString(k.ContainerId)
+		h.WriteString(k.KubernetesPodName)
+
+		h.WriteString(k.ServiceVersion)
+		h.WriteString(k.ServiceNodeName)
+
+		h.WriteString(k.ServiceRuntimeName)
+		h.WriteString(k.ServiceRuntimeVersion)
+		h.WriteString(k.ServiceLanguageVersion)
+
+		h.WriteString(k.HostHostname)
+		h.WriteString(k.HostName)
+		h.WriteString(k.HostOsPlatform)
+
+		h.WriteString(k.EventOutcome)
+
+		h.WriteString(k.TransactionName)
+		h.WriteString(k.TransactionType)
+		h.WriteString(k.TransactionResult)
+
+		if k.FaasColdstart == uint32(True) {
+			h.WriteString("1")
+		}
+		h.WriteString(k.FaasId)
+		h.WriteString(k.FaasName)
+		h.WriteString(k.FaasVersion)
+		h.WriteString(k.FaasTriggerType)
+
+		h.WriteString(k.CloudProvider)
+		h.WriteString(k.CloudRegion)
+		h.WriteString(k.CloudAvailabilityZone)
+		h.WriteString(k.CloudServiceName)
+		h.WriteString(k.CloudAccountId)
+		h.WriteString(k.CloudAccountName)
+		h.WriteString(k.CloudMachineType)
+		h.WriteString(k.CloudProjectId)
+		h.WriteString(k.CloudProjectName)
+		return h
+	})
 }

--- a/aggregators/hasher_test.go
+++ b/aggregators/hasher_test.go
@@ -12,19 +12,13 @@ import (
 	"github.com/cespare/xxhash/v2"
 )
 
-type testHashable func(xxhash.Digest) xxhash.Digest
-
-func (f testHashable) Hash(h xxhash.Digest) xxhash.Digest {
-	return f(h)
-}
-
 func TestHasher(t *testing.T) {
 	a := Hasher{}
-	b := a.Chain(testHashable(func(h xxhash.Digest) xxhash.Digest {
+	b := a.Chain(HashableFunc(func(h xxhash.Digest) xxhash.Digest {
 		h.WriteString("1")
 		return h
 	}))
-	c := a.Chain(testHashable(func(h xxhash.Digest) xxhash.Digest {
+	c := a.Chain(HashableFunc(func(h xxhash.Digest) xxhash.Digest {
 		h.WriteString("1")
 		return h
 	}))

--- a/aggregators/merger_test.go
+++ b/aggregators/merger_test.go
@@ -534,6 +534,8 @@ type testSpan struct {
 	spanName            string
 	destinationResource string
 	targetName          string
+	targetType          string
+	outcome             string
 	count               int
 }
 
@@ -557,7 +559,9 @@ func spanKeyFromTestSpan(span testSpan) SpanAggregationKey {
 	return SpanAggregationKey{
 		SpanName:   span.spanName,
 		TargetName: span.targetName,
+		TargetType: span.targetType,
 		Resource:   span.destinationResource,
+		Outcome:    span.outcome,
 	}
 }
 

--- a/aggregators/models.go
+++ b/aggregators/models.go
@@ -447,21 +447,3 @@ type GlobalLabels struct {
 	Labels        modelpb.Labels
 	NumericLabels modelpb.NumericLabels
 }
-
-func (gl *GlobalLabels) fromLabelsAndNumericLabels(labels modelpb.Labels, numericLabels modelpb.NumericLabels) {
-	gl.Labels = make(modelpb.Labels)
-	for k, v := range labels {
-		if !v.Global {
-			continue
-		}
-		gl.Labels[k] = v
-	}
-
-	gl.NumericLabels = make(modelpb.NumericLabels)
-	for k, v := range numericLabels {
-		if !v.Global {
-			continue
-		}
-		gl.NumericLabels[k] = v
-	}
-}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.39.0
 	go.opentelemetry.io/otel/trace v1.16.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/sync v0.3.0
 	google.golang.org/protobuf v1.31.0
 )
@@ -55,7 +56,6 @@ require (
 	go.elastic.co/fastjson v1.3.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20200513190911-00229845015e // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20200513190911-00229845015e h1:rMqLP+9XLy+LdbCXHjJHAmTfXCr93W7oruWA6Hq1Alc=
-golang.org/x/exp v0.0.0-20200513190911-00229845015e/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=


### PR DESCRIPTION
Removes the translation layer for calls to `AggregateBatch`.

Before, for every received `APMEvent` we will create a intermediary model which would eventually get translated to the proto model. The proto model would get marshaled to binary representation and indexed in pebble.

After this PR, we directly create the proto model for every received `APMEvent`.

Benchmarking results:

```
name                         old time/op    new time/op    delta
AggregateCombinedMetrics-10    2.79µs ± 2%    3.60µs ± 4%  +29.06%  (p=0.000 n=10+10)
AggregateBatchSerial-10        12.7µs ± 3%     9.1µs ± 2%  -28.38%  (p=0.000 n=10+9)
AggregateBatchParallel-10      14.2µs ± 3%     9.3µs ± 2%  -34.37%  (p=0.000 n=10+9)
CombinedMetricsEncoding-10     3.89µs ± 1%    3.71µs ± 1%   -4.69%  (p=0.000 n=10+10)
CombinedMetricsDecoding-10     4.59µs ± 2%    4.60µs ± 1%     ~     (p=0.739 n=10+10)
CombinedMetricsToBatch-10       361µs ± 1%     372µs ± 1%   +3.17%  (p=0.000 n=10+10)
EventToCombinedMetrics-10      1.85µs ± 5%    0.78µs ± 2%  -57.98%  (p=0.000 n=10+10)

name                         old alloc/op   new alloc/op   delta
AggregateCombinedMetrics-10    3.88kB ± 3%    5.11kB ± 3%  +31.76%  (p=0.000 n=10+9)
AggregateBatchSerial-10        24.6kB ± 0%    11.8kB ± 0%  -51.98%  (p=0.000 n=8+10)
AggregateBatchParallel-10      24.6kB ± 0%    11.8kB ± 1%  -52.03%  (p=0.000 n=9+10)
CombinedMetricsEncoding-10      0.00B          0.00B          ~     (all equal)
CombinedMetricsDecoding-10     10.3kB ± 0%    10.3kB ± 0%     ~     (all equal)
CombinedMetricsToBatch-10      38.6kB ± 0%    38.6kB ± 0%     ~     (all equal)
EventToCombinedMetrics-10      4.29kB ± 0%    0.08kB ± 0%  -98.13%  (p=0.000 n=10+10)

name                         old allocs/op  new allocs/op  delta
AggregateCombinedMetrics-10      29.4 ± 2%      39.5 ± 4%  +34.35%  (p=0.000 n=10+10)
AggregateBatchSerial-10           112 ± 0%        79 ± 0%  -29.46%  (p=0.000 n=10+10)
AggregateBatchParallel-10         112 ± 0%        79 ± 0%  -29.46%  (p=0.000 n=9+10)
CombinedMetricsEncoding-10       0.00           0.00          ~     (all equal)
CombinedMetricsDecoding-10       40.0 ± 0%      40.0 ± 0%     ~     (all equal)
CombinedMetricsToBatch-10         308 ± 0%       308 ± 0%     ~     (all equal)
EventToCombinedMetrics-10        17.0 ± 0%       6.0 ± 0%  -64.71%  (p=0.000 n=10+10)
```

The changes in `AggregateCombinedMetrics` are a result of changes in how we create the input. Using the same logic on `main` the differences are negligible:

```
name                         old time/op    new time/op    delta
AggregateCombinedMetrics-10    3.90µs ± 4%    3.60µs ± 4%  -7.76%  (p=0.000 n=10+10)

name                         old alloc/op   new alloc/op   delta
AggregateCombinedMetrics-10    4.93kB ± 3%    5.11kB ± 3%  +3.72%  (p=0.000 n=10+9)

name                         old allocs/op  new allocs/op  delta
AggregateCombinedMetrics-10      38.0 ± 3%      39.5 ± 4%  +3.95%  (p=0.001 n=10+10)
```