### PR TITLE
Switch to sync.Map for cached event stats

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -93,7 +93,7 @@ func (m *cachedEventsMap) loadAndDelete(end time.Time) map[time.Duration]map[[16
 		value := float64(vscaled / math.MaxUint16)
 		intervalMetrics[key.id] = value
 		m.m.Delete(k)
-		m.countPool.Put(vscaled)
+		m.countPool.Put(v)
 		return true
 	})
 	return loaded


### PR DESCRIPTION
This removes the need for exclusive locking to update the cached event stats in `Aggregate*` methods.

The cperformance changes are negligible, which is expected. I think CombinedMetricsEncoding-16 has more variance than the benchstat output lets on -- in another run it was faster than main, but with a wider range.

```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics     
                            │ /tmp/main.txt │            /tmp/pr.txt             │
                            │    sec/op     │    sec/op     vs base              │
AggregateCombinedMetrics       8.373µ ±  6%   8.262µ ±  2%       ~ (p=0.485 n=6)
AggregateCombinedMetrics-8     6.322µ ± 11%   6.393µ ± 10%       ~ (p=0.699 n=6)
AggregateCombinedMetrics-16    6.610µ ±  9%   6.338µ ± 10%       ~ (p=0.937 n=6)
AggregateBatchSerial           35.43µ ±  4%   35.46µ ±  7%       ~ (p=0.937 n=6)
AggregateBatchSerial-8         33.41µ ± 16%   34.42µ ± 12%       ~ (p=1.000 n=6)
AggregateBatchSerial-16        32.73µ ±  5%   33.73µ ± 10%       ~ (p=0.818 n=6)
AggregateBatchParallel         35.08µ ±  6%   34.27µ ±  6%  -2.31% (p=0.026 n=6)
AggregateBatchParallel-8       43.49µ ± 11%   41.08µ ± 15%       ~ (p=0.394 n=6)
AggregateBatchParallel-16      45.19µ ± 12%   42.66µ ± 20%       ~ (p=0.485 n=6)
CombinedMetricsEncoding        4.936µ ±  4%   4.986µ ±  4%       ~ (p=0.485 n=6)
CombinedMetricsEncoding-8      5.064µ ±  5%   5.296µ ±  7%       ~ (p=0.589 n=6)
CombinedMetricsEncoding-16     5.106µ ±  3%   5.370µ ±  3%  +5.17% (p=0.002 n=6)
CombinedMetricsDecoding        6.496µ ±  7%   6.660µ ±  8%       ~ (p=0.818 n=6)
CombinedMetricsDecoding-8      6.939µ ±  7%   7.083µ ±  7%       ~ (p=0.589 n=6)
CombinedMetricsDecoding-16     6.745µ ±  9%   6.795µ ±  7%       ~ (p=0.853 n=6)
CombinedMetricsToBatch         510.5µ ±  3%   513.7µ ±  2%       ~ (p=0.240 n=6)
CombinedMetricsToBatch-8       527.7µ ±  4%   526.6µ ±  3%       ~ (p=0.818 n=6)
CombinedMetricsToBatch-16      527.1µ ±  6%   525.6µ ±  3%       ~ (p=0.818 n=6)
EventToCombinedMetrics         3.231µ ±  3%   3.228µ ±  2%       ~ (p=1.000 n=6)
EventToCombinedMetrics-8       3.401µ ± 10%   3.421µ ±  4%       ~ (p=0.699 n=6)
EventToCombinedMetrics-16      3.514µ ±  7%   3.482µ ±  6%       ~ (p=0.699 n=6)
geomean                        17.88µ         17.91µ        +0.16%

                            │  /tmp/main.txt  │              /tmp/pr.txt              │
                            │      B/op       │     B/op       vs base                │
AggregateCombinedMetrics      3.474Ki ±  7%     3.467Ki ±  1%       ~ (p=0.784 n=6)
AggregateCombinedMetrics-8    3.207Ki ± 10%     3.278Ki ± 17%       ~ (p=0.589 n=6)
AggregateCombinedMetrics-16   2.892Ki ± 22%     2.921Ki ± 20%       ~ (p=0.818 n=6)
AggregateBatchSerial          24.02Ki ±  0%     23.93Ki ±  0%       ~ (p=0.102 n=6)
AggregateBatchSerial-8        24.00Ki ±  0%     24.09Ki ±  1%       ~ (p=0.180 n=6)
AggregateBatchSerial-16       24.00Ki ±  0%     23.98Ki ±  0%       ~ (p=1.000 n=6)
AggregateBatchParallel        23.95Ki ±  0%     23.96Ki ±  0%       ~ (p=0.894 n=6)
AggregateBatchParallel-8      23.79Ki ±  2%     24.01Ki ±  0%       ~ (p=0.485 n=6)
AggregateBatchParallel-16     23.87Ki ±  1%     24.02Ki ±  3%       ~ (p=0.394 n=6)
CombinedMetricsEncoding         0.000 ±   ?       0.000 ±   ?       ~ (p=1.000 n=6)
CombinedMetricsEncoding-8       0.000 ±  0%       0.000 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsEncoding-16      0.000 ±  0%       0.000 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsDecoding       10.01Ki ±  0%     10.01Ki ±  0%       ~ (p=0.636 n=6)
CombinedMetricsDecoding-8     10.01Ki ±  0%     10.01Ki ±  0%       ~ (p=0.242 n=6)
CombinedMetricsDecoding-16    10.01Ki ±  0%     10.01Ki ±  0%       ~ (p=0.242 n=6)
CombinedMetricsToBatch        37.66Ki ±  0%     37.66Ki ±  0%       ~ (p=1.000 n=6)
CombinedMetricsToBatch-8      37.66Ki ±  0%     37.66Ki ±  0%       ~ (p=1.000 n=6)
CombinedMetricsToBatch-16     37.66Ki ±  0%     37.66Ki ±  0%       ~ (p=1.000 n=6)
EventToCombinedMetrics        4.188Ki ±  0%     4.188Ki ±  0%       ~ (p=1.000 n=6) ¹
EventToCombinedMetrics-8      4.188Ki ±  0%     4.188Ki ±  0%       ~ (p=1.000 n=6) ¹
EventToCombinedMetrics-16     4.188Ki ±  0%     4.188Ki ±  0%       ~ (p=1.000 n=6) ¹
geomean                                     ²                  +0.21%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                            │ /tmp/main.txt │             /tmp/pr.txt             │
                            │   allocs/op   │  allocs/op   vs base                │
AggregateCombinedMetrics      28.00 ±  7%     28.00 ±  4%       ~ (p=1.000 n=6)
AggregateCombinedMetrics-8    26.00 ±  8%     26.50 ± 13%       ~ (p=0.537 n=6)
AggregateCombinedMetrics-16   24.50 ± 14%     24.50 ± 14%       ~ (p=1.000 n=6)
AggregateBatchSerial          112.0 ±  0%     112.0 ±  0%       ~ (p=1.000 n=6) ¹
AggregateBatchSerial-8        112.0 ±  0%     112.0 ±  0%       ~ (p=1.000 n=6) ¹
AggregateBatchSerial-16       112.0 ±  0%     112.0 ±  0%       ~ (p=1.000 n=6) ¹
AggregateBatchParallel        112.0 ±  0%     112.0 ±  0%       ~ (p=1.000 n=6) ¹
AggregateBatchParallel-8      111.0 ±  4%     112.0 ±  1%       ~ (p=0.182 n=6)
AggregateBatchParallel-16     111.0 ±  3%     112.0 ±  4%       ~ (p=0.545 n=6)
CombinedMetricsEncoding       0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsEncoding-8     0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsEncoding-16    0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsDecoding       40.00 ±  0%     40.00 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsDecoding-8     40.00 ±  0%     40.00 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsDecoding-16    40.00 ±  0%     40.00 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsToBatch        308.0 ±  0%     308.0 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsToBatch-8      308.0 ±  0%     308.0 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsToBatch-16     308.0 ±  0%     308.0 ±  0%       ~ (p=1.000 n=6) ¹
EventToCombinedMetrics        17.00 ±  0%     17.00 ±  0%       ~ (p=1.000 n=6) ¹
EventToCombinedMetrics-8      17.00 ±  0%     17.00 ±  0%       ~ (p=1.000 n=6) ¹
EventToCombinedMetrics-16     17.00 ±  0%     17.00 ±  0%       ~ (p=1.000 n=6) ¹
geomean                                   ²                +0.18%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```