### PR TITLE
Avoid alloc on creating hashable func

### DIFF
--- a/aggregationpb/hash.go
+++ b/aggregationpb/hash.go
@@ -1,0 +1,91 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package aggregationpb
+
+import (
+	"encoding/binary"
+
+	"github.com/cespare/xxhash/v2"
+
+	"github.com/elastic/apm-aggregation/aggregators/nullable"
+)
+
+func (k *ServiceAggregationKey) Hash(h xxhash.Digest) xxhash.Digest {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], k.Timestamp)
+	h.Write(buf[:])
+
+	h.WriteString(k.ServiceName)
+	h.WriteString(k.ServiceEnvironment)
+	h.WriteString(k.ServiceLanguageName)
+	h.WriteString(k.AgentName)
+	return h
+}
+
+func (k *ServiceInstanceAggregationKey) Hash(h xxhash.Digest) xxhash.Digest {
+	h.Write(k.GlobalLabelsStr)
+	return h
+}
+
+func (k *ServiceTransactionAggregationKey) Hash(h xxhash.Digest) xxhash.Digest {
+	h.WriteString(k.TransactionType)
+	return h
+}
+
+func (k *SpanAggregationKey) Hash(h xxhash.Digest) xxhash.Digest {
+	h.WriteString(k.SpanName)
+	h.WriteString(k.Outcome)
+
+	h.WriteString(k.TargetType)
+	h.WriteString(k.TargetName)
+
+	h.WriteString(k.Resource)
+	return h
+}
+
+func (k *TransactionAggregationKey) Hash(h xxhash.Digest) xxhash.Digest {
+	if k.TraceRoot {
+		h.WriteString("1")
+	}
+
+	h.WriteString(k.ContainerId)
+	h.WriteString(k.KubernetesPodName)
+
+	h.WriteString(k.ServiceVersion)
+	h.WriteString(k.ServiceNodeName)
+
+	h.WriteString(k.ServiceRuntimeName)
+	h.WriteString(k.ServiceRuntimeVersion)
+	h.WriteString(k.ServiceLanguageVersion)
+
+	h.WriteString(k.HostHostname)
+	h.WriteString(k.HostName)
+	h.WriteString(k.HostOsPlatform)
+
+	h.WriteString(k.EventOutcome)
+
+	h.WriteString(k.TransactionName)
+	h.WriteString(k.TransactionType)
+	h.WriteString(k.TransactionResult)
+
+	if k.FaasColdstart == uint32(nullable.True) {
+		h.WriteString("1")
+	}
+	h.WriteString(k.FaasId)
+	h.WriteString(k.FaasName)
+	h.WriteString(k.FaasVersion)
+	h.WriteString(k.FaasTriggerType)
+
+	h.WriteString(k.CloudProvider)
+	h.WriteString(k.CloudRegion)
+	h.WriteString(k.CloudAvailabilityZone)
+	h.WriteString(k.CloudServiceName)
+	h.WriteString(k.CloudAccountId)
+	h.WriteString(k.CloudAccountName)
+	h.WriteString(k.CloudMachineType)
+	h.WriteString(k.CloudProjectId)
+	h.WriteString(k.CloudProjectName)
+	return h
+}

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -328,7 +328,7 @@ func (k *TransactionAggregationKey) FromProto(pb *aggregationpb.TransactionAggre
 	k.TransactionType = pb.TransactionType
 	k.TransactionResult = pb.TransactionResult
 
-	k.FAASColdstart = nullable.NullableBool(pb.FaasColdstart)
+	k.FAASColdstart = nullable.Bool(pb.FaasColdstart)
 	k.FAASID = pb.FaasId
 	k.FAASName = pb.FaasName
 	k.FAASVersion = pb.FaasVersion

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -10,7 +10,6 @@ package aggregators
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/elastic/apm-aggregation/aggregators/nullable"
 	"sort"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/elastic/apm-aggregation/aggregationpb"
 	"github.com/elastic/apm-aggregation/aggregators/internal/hdrhistogram"
 	"github.com/elastic/apm-aggregation/aggregators/internal/timestamppb"
+	"github.com/elastic/apm-aggregation/aggregators/nullable"
 	"github.com/elastic/apm-data/model/modelpb"
 )
 

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -10,6 +10,7 @@ package aggregators
 import (
 	"encoding/binary"
 	"errors"
+	"github.com/elastic/apm-aggregation/aggregators/nullable"
 	"sort"
 	"time"
 
@@ -327,7 +328,7 @@ func (k *TransactionAggregationKey) FromProto(pb *aggregationpb.TransactionAggre
 	k.TransactionType = pb.TransactionType
 	k.TransactionResult = pb.TransactionResult
 
-	k.FAASColdstart = NullableBool(pb.FaasColdstart)
+	k.FAASColdstart = nullable.NullableBool(pb.FaasColdstart)
 	k.FAASID = pb.FaasId
 	k.FAASName = pb.FaasName
 	k.FAASVersion = pb.FaasVersion

--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -775,7 +775,7 @@ func serviceInstanceKey(e *modelpb.APMEvent) (*aggregationpb.ServiceInstanceAggr
 }
 
 func transactionKey(e *modelpb.APMEvent) *aggregationpb.TransactionAggregationKey {
-	var faasColdstart nullable.NullableBool
+	var faasColdstart nullable.Bool
 	faas := e.GetFaas()
 	if faas != nil {
 		faasColdstart.ParseBoolPtr(faas.ColdStart)

--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -7,7 +7,6 @@ package aggregators
 import (
 	"errors"
 	"fmt"
-	"github.com/elastic/apm-aggregation/aggregators/nullable"
 	"math"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/elastic/apm-aggregation/aggregationpb"
 	"github.com/elastic/apm-aggregation/aggregators/internal/hdrhistogram"
 	tspb "github.com/elastic/apm-aggregation/aggregators/internal/timestamppb"
+	"github.com/elastic/apm-aggregation/aggregators/nullable"
 	"github.com/elastic/apm-data/model/modelpb"
 )
 

--- a/aggregators/hasher.go
+++ b/aggregators/hasher.go
@@ -5,11 +5,7 @@
 package aggregators
 
 import (
-	"encoding/binary"
-
 	"github.com/cespare/xxhash/v2"
-
-	"github.com/elastic/apm-aggregation/aggregationpb"
 )
 
 // HashableFunc is a function type that implements Hashable.
@@ -38,102 +34,4 @@ func (h Hasher) Chain(hashable Hashable) Hasher {
 // Sum returns the hash for all the chained interfaces.
 func (h Hasher) Sum() uint64 {
 	return h.digest.Sum64()
-}
-
-func serviceKeyHasher(
-	k *aggregationpb.ServiceAggregationKey,
-) Hashable {
-	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
-		var buf [8]byte
-		binary.LittleEndian.PutUint64(buf[:], k.Timestamp)
-		h.Write(buf[:])
-
-		h.WriteString(k.ServiceName)
-		h.WriteString(k.ServiceEnvironment)
-		h.WriteString(k.ServiceLanguageName)
-		h.WriteString(k.AgentName)
-		return h
-	})
-}
-
-func serviceInstanceKeyHasher(
-	k *aggregationpb.ServiceInstanceAggregationKey,
-) Hashable {
-	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
-		h.Write(k.GlobalLabelsStr)
-		return h
-	})
-}
-
-func serviceTransactionKeyHasher(
-	k *aggregationpb.ServiceTransactionAggregationKey,
-) Hashable {
-	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
-		h.WriteString(k.TransactionType)
-		return h
-	})
-}
-
-func spanKeyHasher(
-	k *aggregationpb.SpanAggregationKey,
-) Hashable {
-	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
-		h.WriteString(k.SpanName)
-		h.WriteString(k.Outcome)
-
-		h.WriteString(k.TargetType)
-		h.WriteString(k.TargetName)
-
-		h.WriteString(k.Resource)
-		return h
-	})
-}
-
-func transactionKeyHasher(
-	k *aggregationpb.TransactionAggregationKey,
-) Hashable {
-	return HashableFunc(func(h xxhash.Digest) xxhash.Digest {
-		if k.TraceRoot {
-			h.WriteString("1")
-		}
-
-		h.WriteString(k.ContainerId)
-		h.WriteString(k.KubernetesPodName)
-
-		h.WriteString(k.ServiceVersion)
-		h.WriteString(k.ServiceNodeName)
-
-		h.WriteString(k.ServiceRuntimeName)
-		h.WriteString(k.ServiceRuntimeVersion)
-		h.WriteString(k.ServiceLanguageVersion)
-
-		h.WriteString(k.HostHostname)
-		h.WriteString(k.HostName)
-		h.WriteString(k.HostOsPlatform)
-
-		h.WriteString(k.EventOutcome)
-
-		h.WriteString(k.TransactionName)
-		h.WriteString(k.TransactionType)
-		h.WriteString(k.TransactionResult)
-
-		if k.FaasColdstart == uint32(True) {
-			h.WriteString("1")
-		}
-		h.WriteString(k.FaasId)
-		h.WriteString(k.FaasName)
-		h.WriteString(k.FaasVersion)
-		h.WriteString(k.FaasTriggerType)
-
-		h.WriteString(k.CloudProvider)
-		h.WriteString(k.CloudRegion)
-		h.WriteString(k.CloudAvailabilityZone)
-		h.WriteString(k.CloudServiceName)
-		h.WriteString(k.CloudAccountId)
-		h.WriteString(k.CloudAccountName)
-		h.WriteString(k.CloudMachineType)
-		h.WriteString(k.CloudProjectId)
-		h.WriteString(k.CloudProjectName)
-		return h
-	})
 }

--- a/aggregators/models.go
+++ b/aggregators/models.go
@@ -12,49 +12,9 @@ import (
 	"github.com/cespare/xxhash/v2"
 
 	"github.com/elastic/apm-aggregation/aggregators/internal/hdrhistogram"
+	"github.com/elastic/apm-aggregation/aggregators/nullable"
 	"github.com/elastic/apm-data/model/modelpb"
 )
-
-// NullableBool represents a bool value which can be set to nil.
-// Using uint32 since uint32 is smallest proto type.
-type NullableBool uint32
-
-const (
-	// Nil represents an unset bool value.
-	Nil NullableBool = iota
-	// False represents a false bool value.
-	False
-	// True represents a true bool value.
-	True
-)
-
-// ParseBoolPtr sets nullable bool from bool pointer.
-func (nb *NullableBool) ParseBoolPtr(b *bool) {
-	if b == nil {
-		*nb = Nil
-		return
-	}
-	if *b {
-		*nb = True
-		return
-	}
-	*nb = False
-}
-
-// ToBoolPtr converts Nullable bool to bool pointer.
-func (nb *NullableBool) ToBoolPtr() *bool {
-	if nb == nil || *nb == Nil {
-		return nil
-	}
-	var b bool
-	switch *nb {
-	case False:
-		b = false
-	case True:
-		b = true
-	}
-	return &b
-}
 
 // Limits define the aggregation limits. Once the limits are reached
 // the metrics will overflow into dedicated overflow buckets.
@@ -306,7 +266,7 @@ type TransactionAggregationKey struct {
 	TransactionType   string
 	TransactionResult string
 
-	FAASColdstart   NullableBool
+	FAASColdstart   nullable.NullableBool
 	FAASID          string
 	FAASName        string
 	FAASVersion     string
@@ -349,7 +309,7 @@ func (k TransactionAggregationKey) Hash(h xxhash.Digest) xxhash.Digest {
 	h.WriteString(k.TransactionType)
 	h.WriteString(k.TransactionResult)
 
-	if k.FAASColdstart == True {
+	if k.FAASColdstart == nullable.True {
 		h.WriteString("1")
 	}
 	h.WriteString(k.FAASID)

--- a/aggregators/models.go
+++ b/aggregators/models.go
@@ -266,7 +266,7 @@ type TransactionAggregationKey struct {
 	TransactionType   string
 	TransactionResult string
 
-	FAASColdstart   nullable.NullableBool
+	FAASColdstart   nullable.Bool
 	FAASID          string
 	FAASName        string
 	FAASVersion     string

--- a/aggregators/nullable/bool.go
+++ b/aggregators/nullable/bool.go
@@ -1,0 +1,46 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package nullable
+
+// NullableBool represents a bool value which can be set to nil.
+// Using uint32 since uint32 is smallest proto type.
+type NullableBool uint32
+
+const (
+	// Nil represents an unset bool value.
+	Nil NullableBool = iota
+	// False represents a false bool value.
+	False
+	// True represents a true bool value.
+	True
+)
+
+// ParseBoolPtr sets nullable bool from bool pointer.
+func (nb *NullableBool) ParseBoolPtr(b *bool) {
+	if b == nil {
+		*nb = Nil
+		return
+	}
+	if *b {
+		*nb = True
+		return
+	}
+	*nb = False
+}
+
+// ToBoolPtr converts Nullable bool to bool pointer.
+func (nb *NullableBool) ToBoolPtr() *bool {
+	if nb == nil || *nb == Nil {
+		return nil
+	}
+	var b bool
+	switch *nb {
+	case False:
+		b = false
+	case True:
+		b = true
+	}
+	return &b
+}

--- a/aggregators/nullable/bool.go
+++ b/aggregators/nullable/bool.go
@@ -4,13 +4,13 @@
 
 package nullable
 
-// NullableBool represents a bool value which can be set to nil.
+// Bool represents a bool value which can be set to nil.
 // Using uint32 since uint32 is smallest proto type.
-type NullableBool uint32
+type Bool uint32
 
 const (
 	// Nil represents an unset bool value.
-	Nil NullableBool = iota
+	Nil Bool = iota
 	// False represents a false bool value.
 	False
 	// True represents a true bool value.
@@ -18,7 +18,7 @@ const (
 )
 
 // ParseBoolPtr sets nullable bool from bool pointer.
-func (nb *NullableBool) ParseBoolPtr(b *bool) {
+func (nb *Bool) ParseBoolPtr(b *bool) {
 	if b == nil {
 		*nb = Nil
 		return
@@ -30,8 +30,8 @@ func (nb *NullableBool) ParseBoolPtr(b *bool) {
 	*nb = False
 }
 
-// ToBoolPtr converts Nullable bool to bool pointer.
-func (nb *NullableBool) ToBoolPtr() *bool {
+// ToBoolPtr converts nullable bool to bool pointer.
+func (nb *Bool) ToBoolPtr() *bool {
 	if nb == nil || *nb == Nil {
 		return nil
 	}

--- a/aggregators/nullable/doc.go
+++ b/aggregators/nullable/doc.go
@@ -1,0 +1,6 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+// Package nullable contains nullable types.
+package nullable


### PR DESCRIPTION
benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                            │ bench-out/hashable-func-alloc-before │ bench-out/hashable-func-alloc-after │
                            │                sec/op                │   sec/op     vs base                │
AggregateCombinedMetrics-16                            4.003µ ± 3%   4.072µ ± 2%        ~ (p=0.342 n=10)
AggregateBatchSerial-16                                10.46µ ± 3%   10.26µ ± 4%        ~ (p=0.645 n=10)
AggregateBatchParallel-16                              11.07µ ± 5%   10.73µ ± 5%        ~ (p=0.190 n=10)
CombinedMetricsEncoding-16                             4.842µ ± 2%   4.829µ ± 3%        ~ (p=0.869 n=10)
CombinedMetricsDecoding-16                             4.449µ ± 2%   4.494µ ± 2%        ~ (p=0.247 n=10)
CombinedMetricsToBatch-16                              417.2µ ± 3%   418.9µ ± 2%        ~ (p=0.912 n=10)
EventToCombinedMetrics-16                             1007.0n ± 2%   845.4n ± 2%  -16.05% (p=0.000 n=10)
geomean                                                8.832µ        8.588µ        -2.77%

                            │ bench-out/hashable-func-alloc-before │  bench-out/hashable-func-alloc-after   │
                            │                 B/op                 │     B/op      vs base                  │
AggregateCombinedMetrics-16                         4.862Ki ± 2%     4.868Ki ± 1%        ~ (p=0.956 n=10)
AggregateBatchSerial-16                             11.48Ki ± 1%     11.34Ki ± 0%   -1.17% (p=0.000 n=10)
AggregateBatchParallel-16                           11.51Ki ± 1%     11.32Ki ± 1%   -1.67% (p=0.000 n=10)
CombinedMetricsEncoding-16                            0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
CombinedMetricsDecoding-16                          10.01Ki ± 0%     10.01Ki ± 0%        ~ (p=0.593 n=10)
CombinedMetricsToBatch-16                           37.66Ki ± 0%     37.66Ki ± 0%        ~ (p=1.000 n=10) ¹
EventToCombinedMetrics-16                             80.00 ± 0%       16.00 ± 0%  -80.00% (p=0.000 n=10)
geomean                                                          ²                 -20.85%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                            │ bench-out/hashable-func-alloc-before │ bench-out/hashable-func-alloc-after  │
                            │              allocs/op               │ allocs/op   vs base                  │
AggregateCombinedMetrics-16                           39.00 ± 3%     39.00 ± 3%        ~ (p=1.000 n=10)
AggregateBatchSerial-16                               79.00 ± 0%     67.00 ± 1%  -15.19% (p=0.000 n=10)
AggregateBatchParallel-16                             79.00 ± 0%     67.00 ± 0%  -15.19% (p=0.000 n=10)
CombinedMetricsEncoding-16                            0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
CombinedMetricsDecoding-16                            40.00 ± 0%     40.00 ± 0%        ~ (p=1.000 n=10) ¹
CombinedMetricsToBatch-16                             308.0 ± 0%     308.0 ± 0%        ~ (p=1.000 n=10) ¹
EventToCombinedMetrics-16                             6.000 ± 0%     2.000 ± 0%  -66.67% (p=0.000 n=10)
geomean                                                          ²               -18.46%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```