### PR TITLE
aggregators: refactor, introduce Writer

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -9,20 +9,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/pebble"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
-	"github.com/elastic/apm-aggregation/aggregationpb"
 	"github.com/elastic/apm-aggregation/aggregators/internal/telemetry"
-	"github.com/elastic/apm-data/model/modelpb"
 )
 
 const (
@@ -31,12 +26,9 @@ const (
 )
 
 var (
-	// ErrAggregatorStopped means that aggregator was stopped when the
+	// ErrAggregatorClosed means that aggregator was closed when the
 	// method was called and thus cannot be processed further.
-	ErrAggregatorStopped = errors.New("aggregator is stopping or stopped")
-	// ErrAggregatorAlreadyRunning means that aggregator Run method is
-	// called while the aggregator is already running.
-	ErrAggregatorAlreadyRunning = errors.New("aggregator is already running")
+	ErrAggregatorClosed = errors.New("aggregator is closed")
 )
 
 // Aggregator represents a LSM based aggregator instance to generate
@@ -48,84 +40,19 @@ var (
 // same processing time bucket and thereafter the processing time
 // bucket is advanced in factors of aggregation interval.
 type Aggregator struct {
-	db  *pebble.DB
-	cfg Config
+	db           *pebble.DB
+	writeOptions *pebble.WriteOptions
+	cfg          Config
 
-	mu             sync.Mutex
+	mu             sync.RWMutex
+	writers        sync.Map
 	processingTime time.Time
-	batch          *pebble.Batch
 	cachedEvents   cachedEventsMap
 
-	stopping   chan struct{}
-	runStarted atomic.Bool
-	runStopped chan struct{}
+	closed            chan struct{}
+	harvestingStopped chan struct{}
 
 	metrics *telemetry.Metrics
-}
-
-// cachedEventsMap holds a counts of cached events, keyed by interval and ID.
-// Cached events are events that have been processed by Aggregate methods,
-// but which haven't yet been harvested. Event counts are fractional because
-// an event may be spread over multiple partitions.
-//
-// Access to the map is protected with a mutex. During harvest, an exclusive
-// (write) lock is held. Concurrent aggregations may perform atomic updates
-// to the map, and the harvester may assume that the map will not be modified
-// while it is reading it.
-type cachedEventsMap struct {
-	// (interval, id) -> count
-	m         sync.Map
-	countPool sync.Pool
-}
-
-func (m *cachedEventsMap) loadAndDelete(end time.Time) map[time.Duration]map[[16]byte]float64 {
-	loaded := make(map[time.Duration]map[[16]byte]float64)
-	m.m.Range(func(k, v any) bool {
-		key := k.(cachedEventsStatsKey)
-		if !end.Truncate(key.interval).Equal(end) {
-			return true
-		}
-		intervalMetrics, ok := loaded[key.interval]
-		if !ok {
-			intervalMetrics = make(map[[16]byte]float64)
-			loaded[key.interval] = intervalMetrics
-		}
-		vscaled := *v.(*uint64)
-		value := float64(vscaled / math.MaxUint16)
-		intervalMetrics[key.id] = value
-		m.m.Delete(k)
-		m.countPool.Put(v)
-		return true
-	})
-	return loaded
-}
-
-func (m *cachedEventsMap) add(interval time.Duration, id [16]byte, n float64) {
-	// We use a pool for the value to minimise allocations, as it will
-	// always escape to the heap through LoadOrStore.
-	nscaled, ok := m.countPool.Get().(*uint64)
-	if !ok {
-		nscaled = new(uint64)
-	}
-	// Scale by the maximum number of partitions to get an integer value,
-	// for simpler atomic operations.
-	*nscaled = uint64(n * math.MaxUint16)
-	key := cachedEventsStatsKey{interval: interval, id: id}
-	old, loaded := m.m.Load(key)
-	if !loaded {
-		old, loaded = m.m.LoadOrStore(key, nscaled)
-		if !loaded {
-			// Stored a new value.
-			return
-		}
-	}
-	atomic.AddUint64(old.(*uint64), *nscaled)
-	m.countPool.Put(nscaled)
-}
-
-type cachedEventsStatsKey struct {
-	interval time.Duration
-	id       [16]byte
 }
 
 // New returns a new aggregator instance.
@@ -163,131 +90,129 @@ func New(opts ...Option) (*Aggregator, error) {
 
 	return &Aggregator{
 		db:             pb,
+		writeOptions:   pebble.Sync,
 		cfg:            cfg,
 		processingTime: time.Now().Truncate(cfg.AggregationIntervals[0]),
-		stopping:       make(chan struct{}),
-		runStopped:     make(chan struct{}),
+		closed:         make(chan struct{}),
 		metrics:        metrics,
 	}, nil
 }
 
-// AggregateBatch aggregates all events in the batch. This function will return
-// an error if the aggregator's Run loop has errored or has been explicitly stopped.
-// However, it doesn't require aggregator to be running to perform aggregation.
-func (a *Aggregator) AggregateBatch(
-	ctx context.Context,
-	id [16]byte,
-	b *modelpb.Batch,
-) error {
-	cmIDAttrs := a.cfg.CombinedMetricsIDToKVs(id)
-
+// Close commits and closes any open Writers, performs a final harvest,
+// and closes the underlying database.
+//
+// No further writes may be performed after Close is called,
+// and no further harvests will be performed once Close returns.
+func (a *Aggregator) Close(ctx context.Context) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-a.stopping:
-		return ErrAggregatorStopped
+	case <-a.closed:
 	default:
+		close(a.closed)
 	}
 
 	var errs []error
-	var totalBytesIn int64
-	cmk := CombinedMetricsKey{ID: id}
-	for _, ivl := range a.cfg.AggregationIntervals {
-		cmk.ProcessingTime = a.processingTime.Truncate(ivl)
-		cmk.Interval = ivl
-		for _, e := range *b {
-			bytesIn, err := a.aggregateAPMEvent(ctx, cmk, e)
-			if err != nil {
-				errs = append(errs, err)
-			}
-			totalBytesIn += int64(bytesIn)
+	a.writers.Range(func(_, value any) bool {
+		writer := value.(*Writer)
+		if err := writer.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close writer: %w", err))
 		}
-		a.cachedEvents.add(ivl, id, float64(len(*b)))
+		return true
+	})
+	if a.harvestingStopped != nil {
+		select {
+		case <-ctx.Done():
+			errs = append(errs, fmt.Errorf("context cancelled while waiting for harvesting to stop: %w", ctx.Err()))
+		case <-a.harvestingStopped:
+		}
 	}
+	if a.db != nil {
+		if err := a.finalHarvest(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to perform final harvest: %w", err))
+		}
+		if err := a.db.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close pebble: %w", err))
+		}
+		a.db = nil
+	}
+	if err := a.metrics.CleanUp(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to cleanup instrumentation: %w", err))
+	}
+	return errors.Join(errs...)
+}
 
-	cmIDAttrSet := attribute.NewSet(cmIDAttrs...)
-	a.metrics.RequestsTotal.Add(ctx, 1, metric.WithAttributeSet(cmIDAttrSet))
-	a.metrics.BytesIngested.Add(ctx, totalBytesIn, metric.WithAttributeSet(cmIDAttrSet))
-	if len(errs) > 0 {
-		a.metrics.RequestsFailed.Add(ctx, 1, metric.WithAttributeSet(cmIDAttrSet))
-		return fmt.Errorf("failed batch aggregation:\n%w", errors.Join(errs...))
+// NewWriter returns a new Writer, for adding metric values to be aggregated.
+//
+// The returned Writer will be associated with the aggregator, and will be
+// automatically closed (with any buffered writes committed) when the aggregator
+// is closed.
+//
+// NewWriter will return an error if the aggregator has already been stopped.
+func (a *Aggregator) NewWriter() (*Writer, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	select {
+	case <-a.closed:
+		return nil, ErrAggregatorClosed
+	default:
 	}
+	w := &Writer{aggregator: a, batch: a.db.NewBatch()}
+	a.writers.Store(w, w)
+	return w, nil
+}
+
+// StartHarvesting starts periodically harvesting aggregated metrics.
+//
+// StartHarvester may be called at most once, and will return an error if it
+// is called a second time, or if the aggregator has already been closed.
+func (a *Aggregator) StartHarvesting() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	select {
+	case <-a.closed:
+		return ErrAggregatorClosed
+	default:
+	}
+	if a.harvestingStopped != nil {
+		return errors.New("harvesting already started")
+	}
+	a.harvestingStopped = make(chan struct{})
+	go a.harvestLoop()
 	return nil
 }
 
-// AggregateCombinedMetrics aggregates partial metrics into a bigger aggregate.
-// This function will return an error if the aggregator's Run loop has errored
-// or has been explicitly stopped. However, it doesn't require aggregator to be
-// running to perform aggregation.
-func (a *Aggregator) AggregateCombinedMetrics(
-	ctx context.Context,
-	cmk CombinedMetricsKey,
-	cm *aggregationpb.CombinedMetrics,
-) error {
-	cmIDAttrs := a.cfg.CombinedMetricsIDToKVs(cmk.ID)
-	traceAttrs := append(append([]attribute.KeyValue{}, cmIDAttrs...),
-		attribute.String(aggregationIvlKey, formatDuration(cmk.Interval)),
-		attribute.String("processing_time", cmk.ProcessingTime.String()))
-	ctx, span := a.cfg.Tracer.Start(ctx, "AggregateCombinedMetrics", trace.WithAttributes(traceAttrs...))
-	defer span.End()
+func (a *Aggregator) harvestLoop() {
+	defer close(a.harvestingStopped)
 
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-a.stopping:
-		return ErrAggregatorStopped
-	default:
-	}
-
-	bytesIn, err := a.aggregate(ctx, cmk, cm)
-	a.cachedEvents.add(cmk.Interval, cmk.ID, cm.EventsTotal)
-
-	span.SetAttributes(attribute.Int("bytes_ingested", bytesIn))
-	cmIDAttrSet := attribute.NewSet(cmIDAttrs...)
-	a.metrics.RequestsTotal.Add(ctx, 1, metric.WithAttributeSet(cmIDAttrSet))
-	a.metrics.BytesIngested.Add(ctx, int64(bytesIn), metric.WithAttributeSet(cmIDAttrSet))
-	if err != nil {
-		a.metrics.RequestsFailed.Add(ctx, 1, metric.WithAttributeSet(cmIDAttrSet))
-	}
-	return err
-}
-
-// Run harvests the aggregated results periodically. For an aggregator,
-// Run must be called at-most once.
-// - Running more than once will return ErrAggregatorAlreadyRunning.
-// - Running after aggregator is stopped will return ErrAggregatorStopped.
-func (a *Aggregator) Run(ctx context.Context) error {
-	if !a.runStarted.CompareAndSwap(false, true) {
-		return ErrAggregatorAlreadyRunning
-	}
-	defer close(a.runStopped)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	to := a.processingTime.Add(a.cfg.AggregationIntervals[0])
 	timer := time.NewTimer(time.Until(to.Add(a.cfg.HarvestDelay)))
 	defer timer.Stop()
 	for {
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-a.stopping:
-			return ErrAggregatorStopped
+		case <-a.closed:
+			return
 		case <-timer.C:
 		}
 
+		var commitBatches []*pebble.Batch
 		a.mu.Lock()
-		batch := a.batch
-		a.batch = nil
+		a.writers.Range(func(_, value any) bool {
+			writer := value.(*Writer)
+			if batch, ok := writer.takeBatch(); ok {
+				commitBatches = append(commitBatches, batch)
+			}
+			return true
+		})
 		a.processingTime = to
 		cachedEventsStats := a.cachedEvents.loadAndDelete(to)
 		a.mu.Unlock()
 
-		if err := a.commitAndHarvest(ctx, batch, to, cachedEventsStats); err != nil {
+		if err := a.commitAndHarvest(ctx, commitBatches, to, cachedEventsStats); err != nil {
 			a.cfg.Logger.Warn("failed to commit and harvest metrics", zap.Error(err))
 		}
 		to = to.Add(a.cfg.AggregationIntervals[0])
@@ -295,136 +220,29 @@ func (a *Aggregator) Run(ctx context.Context) error {
 	}
 }
 
-// Stop stops the aggregator. Aggregations performed after calling Stop
-// will return an error. Stop can be called multiple times but concurrent
-// calls to stop will block.
-func (a *Aggregator) Stop(ctx context.Context) error {
-	ctx, span := a.cfg.Tracer.Start(ctx, "Aggregator.Stop")
-	defer span.End()
-
-	a.mu.Lock()
-	select {
-	case <-a.stopping:
-	default:
-		close(a.stopping)
-	}
-	a.mu.Unlock()
-	if a.runStarted.Load() {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("context cancelled while waiting for run to complete: %w", ctx.Err())
-		case <-a.runStopped:
+// finalHarvest is called by Aggregator.Close, even if StartHarvesting is never called.
+func (a *Aggregator) finalHarvest(ctx context.Context) error {
+	var errs []error
+	for _, ivl := range a.cfg.AggregationIntervals {
+		// At any particular time there will be 1 harvest candidate for
+		// each aggregation interval. We will align the end time and
+		// process each of these.
+		//
+		// TODO (lahsivjar): It is possible to harvest the same
+		// time multiple times, not an issue but can be optimized.
+		to := a.processingTime.Truncate(ivl).Add(ivl)
+		if err := a.harvest(ctx, to, a.cachedEvents.loadAndDelete(to)); err != nil {
+			errs = append(errs, fmt.Errorf(
+				"failed to harvest metrics for interval %s: %w", formatDuration(ivl), err),
+			)
 		}
 	}
-
-	a.cfg.Logger.Info("stopping aggregator")
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	if a.db != nil {
-		a.cfg.Logger.Info("running final aggregation")
-		if a.batch != nil {
-			if err := a.batch.Commit(pebble.Sync); err != nil {
-				span.RecordError(err)
-				return fmt.Errorf("failed to commit batch: %w", err)
-			}
-			if err := a.batch.Close(); err != nil {
-				span.RecordError(err)
-				return fmt.Errorf("failed to close batch: %w", err)
-			}
-			a.batch = nil
-		}
-		var errs []error
-		for _, ivl := range a.cfg.AggregationIntervals {
-			// At any particular time there will be 1 harvest candidate for
-			// each aggregation interval. We will align the end time and
-			// process each of these.
-			//
-			// TODO (lahsivjar): It is possible to harvest the same
-			// time multiple times, not an issue but can be optimized.
-			to := a.processingTime.Truncate(ivl).Add(ivl)
-			if err := a.harvest(ctx, to, a.cachedEvents.loadAndDelete(to)); err != nil {
-				span.RecordError(err)
-				errs = append(errs, fmt.Errorf(
-					"failed to harvest metrics for interval %s: %w", formatDuration(ivl), err),
-				)
-			}
-		}
-		if len(errs) > 0 {
-			return fmt.Errorf("failed while running final harvest: %w", errors.Join(errs...))
-		}
-		if err := a.db.Close(); err != nil {
-			span.RecordError(err)
-			return fmt.Errorf("failed to close pebble: %w", err)
-		}
-		// All future operations are invalid after db is closed
-		a.db = nil
-	}
-	if err := a.metrics.CleanUp(); err != nil {
-		span.RecordError(err)
-		return fmt.Errorf("failed to cleanup instrumentation: %w", err)
-	}
-	return nil
-}
-
-func (a *Aggregator) aggregateAPMEvent(
-	ctx context.Context,
-	cmk CombinedMetricsKey,
-	e *modelpb.APMEvent,
-) (int, error) {
-	var totalBytesIn int
-	aggregateFunc := func(k CombinedMetricsKey, m *aggregationpb.CombinedMetrics) error {
-		bytesIn, err := a.aggregate(ctx, k, m)
-		totalBytesIn += bytesIn
-		return err
-	}
-	err := EventToCombinedMetrics(e, cmk, a.cfg.Partitioner, aggregateFunc)
-	if err != nil {
-		return 0, fmt.Errorf("failed to aggregate combined metrics: %w", err)
-	}
-	return totalBytesIn, nil
-}
-
-// aggregate aggregates combined metrics for a given key and returns
-// number of bytes ingested along with the error, if any.
-func (a *Aggregator) aggregate(
-	ctx context.Context,
-	cmk CombinedMetricsKey,
-	cm *aggregationpb.CombinedMetrics,
-) (int, error) {
-	if a.batch == nil {
-		// Batch is backed by a sync pool. After each commit we will release the batch
-		// back to the pool by calling Batch#Close and subsequently acquire a new batch.
-		a.batch = a.db.NewBatch()
-	}
-
-	op := a.batch.MergeDeferred(cmk.SizeBinary(), cm.SizeVT())
-	if err := cmk.MarshalBinaryToSizedBuffer(op.Key); err != nil {
-		return 0, fmt.Errorf("failed to marshal combined metrics key: %w", err)
-	}
-	if _, err := cm.MarshalToSizedBufferVT(op.Value); err != nil {
-		return 0, fmt.Errorf("failed to marshal combined metrics: %w", err)
-	}
-	if err := op.Finish(); err != nil {
-		return 0, fmt.Errorf("failed to finalize merge operation: %w", err)
-	}
-
-	bytesIn := cm.SizeVT()
-	if a.batch.Len() >= dbCommitThresholdBytes {
-		if err := a.batch.Commit(pebble.Sync); err != nil {
-			return bytesIn, fmt.Errorf("failed to commit pebble batch: %w", err)
-		}
-		if err := a.batch.Close(); err != nil {
-			return bytesIn, fmt.Errorf("failed to close pebble batch: %w", err)
-		}
-		a.batch = nil
-	}
-	return bytesIn, nil
+	return errors.Join(errs...)
 }
 
 func (a *Aggregator) commitAndHarvest(
 	ctx context.Context,
-	batch *pebble.Batch,
+	batches []*pebble.Batch,
 	to time.Time,
 	cachedEventsStats map[time.Duration]map[[16]byte]float64,
 ) error {
@@ -432,8 +250,8 @@ func (a *Aggregator) commitAndHarvest(
 	defer span.End()
 
 	var errs []error
-	if batch != nil {
-		if err := batch.Commit(pebble.Sync); err != nil {
+	for _, batch := range batches {
+		if err := batch.Commit(a.writeOptions); err != nil {
 			span.RecordError(err)
 			errs = append(errs, fmt.Errorf("failed to commit batch before harvest: %w", err))
 		}
@@ -567,7 +385,7 @@ func (a *Aggregator) harvestForInterval(
 		a.metrics.ProcessingDelay.Record(ctx, processingDelay, attrSet)
 		a.metrics.EventsProcessed.Add(ctx, harvestStats.eventsTotal, attrSet)
 	}
-	err := a.db.DeleteRange(lb, ub, pebble.Sync)
+	err := a.db.DeleteRange(lb, ub, a.writeOptions)
 	if len(errs) > 0 {
 		err = errors.Join(err, fmt.Errorf(
 			"failed to process %d out of %d metrics:\n%w",

--- a/aggregators/cachedevents.go
+++ b/aggregators/cachedevents.go
@@ -1,0 +1,77 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package aggregators
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// cachedEventsMap holds a counts of cached events, keyed by interval and ID.
+// Cached events are events that have been processed by Aggregate methods,
+// but which haven't yet been harvested. Event counts are fractional because
+// an event may be spread over multiple partitions.
+//
+// Access to the map is protected with a mutex. During harvest, an exclusive
+// (write) lock is held. Concurrent aggregations may perform atomic updates
+// to the map, and the harvester may assume that the map will not be modified
+// while it is reading it.
+type cachedEventsMap struct {
+	// (interval, id) -> count
+	m         sync.Map
+	countPool sync.Pool
+}
+
+func (m *cachedEventsMap) loadAndDelete(end time.Time) map[time.Duration]map[[16]byte]float64 {
+	loaded := make(map[time.Duration]map[[16]byte]float64)
+	m.m.Range(func(k, v any) bool {
+		key := k.(cachedEventsStatsKey)
+		if !end.Truncate(key.interval).Equal(end) {
+			return true
+		}
+		intervalMetrics, ok := loaded[key.interval]
+		if !ok {
+			intervalMetrics = make(map[[16]byte]float64)
+			loaded[key.interval] = intervalMetrics
+		}
+		vscaled := *v.(*uint64)
+		value := float64(vscaled / math.MaxUint16)
+		intervalMetrics[key.id] = value
+		m.m.Delete(k)
+		m.countPool.Put(v)
+		return true
+	})
+	return loaded
+}
+
+func (m *cachedEventsMap) add(interval time.Duration, id [16]byte, n float64) {
+	// We use a pool for the value to minimise allocations, as it will
+	// always escape to the heap through LoadOrStore.
+	nscaled, ok := m.countPool.Get().(*uint64)
+	if !ok {
+		nscaled = new(uint64)
+	}
+	// Scale by the maximum number of partitions to get an integer value,
+	// for simpler atomic operations.
+	*nscaled = uint64(n * math.MaxUint16)
+	key := cachedEventsStatsKey{interval: interval, id: id}
+	old, loaded := m.m.Load(key)
+	if !loaded {
+		old, loaded = m.m.LoadOrStore(key, nscaled)
+		if !loaded {
+			// Stored a new value.
+			return
+		}
+	}
+	atomic.AddUint64(old.(*uint64), *nscaled)
+	m.countPool.Put(nscaled)
+}
+
+type cachedEventsStatsKey struct {
+	interval time.Duration
+	id       [16]byte
+}

--- a/aggregators/writer.go
+++ b/aggregators/writer.go
@@ -117,11 +117,6 @@ func (w *Writer) WriteEventMetrics(ctx context.Context, id [16]byte, events ...*
 // WriteCombinedMetrics writes combined metrics.
 //
 // This function will return an error if the writer has been closed.
-
-// WriteCombinedMetrics writes combined metrics into a bigger aggregate.
-// This function will return an error if the aggregator's Run loop has errored
-// or has been explicitly stopped. However, it doesn't require aggregator to be
-// running to perform aggregation.
 func (w *Writer) WriteCombinedMetrics(
 	ctx context.Context,
 	cmk CombinedMetricsKey,

--- a/aggregators/writer.go
+++ b/aggregators/writer.go
@@ -1,0 +1,190 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+// Package aggregators holds the logic for doing the actual aggregation.
+package aggregators
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/cockroachdb/pebble"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/elastic/apm-aggregation/aggregationpb"
+	"github.com/elastic/apm-data/model/modelpb"
+)
+
+// ErrWriterClosed is returned by Writer methods after the writer is closed.
+var ErrWriterClosed = errors.New("writer is closed")
+
+// Writer provides methods for writing metrics to Pebble.
+type Writer struct {
+	aggregator *Aggregator
+
+	mu    sync.Mutex
+	batch *pebble.Batch
+}
+
+// Close commits and closes the writer's batch,
+// and removes the writer from the aggregator.
+//
+// Writers must not be used again after Close is called.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.batch == nil {
+		return nil
+	}
+	batch := w.batch
+	w.batch = nil
+	w.aggregator.writers.Delete(w)
+	return errors.Join(
+		batch.Commit(w.aggregator.writeOptions),
+		batch.Close(),
+	)
+}
+
+// Commit replaces the writer's batch, and commits any buffered writes.
+func (w *Writer) Commit() error {
+	batch, ok := w.takeBatch()
+	if !ok {
+		return nil
+	}
+	return errors.Join(batch.Commit(w.aggregator.writeOptions), batch.Close())
+}
+
+// takeBatch locks the writer, and if its batch is non-empty, replaces
+// the batch with a new one and returns the old one. If the batch is
+// empty, a nil batch is returned.
+func (w *Writer) takeBatch() (*pebble.Batch, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	batch := w.batch
+	if batch == nil || batch.Empty() {
+		return nil, false
+	}
+	w.batch = w.aggregator.db.NewBatch()
+	return batch, true
+}
+
+// WriteEventMetrics writes metrics for one or more APM events.
+//
+// This function will return an error if the writer has been closed.
+func (w *Writer) WriteEventMetrics(ctx context.Context, id [16]byte, events ...*modelpb.APMEvent) error {
+	w.aggregator.mu.RLock()
+	defer w.aggregator.mu.RUnlock()
+
+	var totalBytesIn int64
+	aggregateFunc := func(k CombinedMetricsKey, m *aggregationpb.CombinedMetrics) error {
+		bytesIn, err := w.writeCombinedMetrics(ctx, k, m)
+		totalBytesIn += int64(bytesIn)
+		if err != nil {
+			return fmt.Errorf("failed to write event metrics: %w", err)
+		}
+		return nil
+	}
+
+	cmk := CombinedMetricsKey{ID: id}
+	var errs []error
+	for _, ivl := range w.aggregator.cfg.AggregationIntervals {
+		cmk.ProcessingTime = w.aggregator.processingTime.Truncate(ivl)
+		cmk.Interval = ivl
+		for _, event := range events {
+			err := EventToCombinedMetrics(event, cmk, w.aggregator.cfg.Partitioner, aggregateFunc)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+		w.aggregator.cachedEvents.add(ivl, id, float64(len(events)))
+	}
+
+	cmIDAttrs := w.aggregator.cfg.CombinedMetricsIDToKVs(id)
+	cmIDAttrSet := attribute.NewSet(cmIDAttrs...)
+	w.aggregator.metrics.RequestsTotal.Add(ctx, 1, metric.WithAttributeSet(cmIDAttrSet))
+	w.aggregator.metrics.BytesIngested.Add(ctx, totalBytesIn, metric.WithAttributeSet(cmIDAttrSet))
+	if len(errs) > 0 {
+		w.aggregator.metrics.RequestsFailed.Add(ctx, 1, metric.WithAttributeSet(cmIDAttrSet))
+		return fmt.Errorf("failed batch aggregation:\n%w", errors.Join(errs...))
+	}
+	return nil
+}
+
+// WriteCombinedMetrics writes combined metrics.
+//
+// This function will return an error if the writer has been closed.
+
+// WriteCombinedMetrics writes combined metrics into a bigger aggregate.
+// This function will return an error if the aggregator's Run loop has errored
+// or has been explicitly stopped. However, it doesn't require aggregator to be
+// running to perform aggregation.
+func (w *Writer) WriteCombinedMetrics(
+	ctx context.Context,
+	cmk CombinedMetricsKey,
+	cm *aggregationpb.CombinedMetrics,
+) error {
+	w.aggregator.mu.RLock()
+	defer w.aggregator.mu.RUnlock()
+
+	bytesIn, err := w.writeCombinedMetrics(ctx, cmk, cm)
+	w.aggregator.cachedEvents.add(cmk.Interval, cmk.ID, cm.EventsTotal)
+
+	cmIDAttrs := w.aggregator.cfg.CombinedMetricsIDToKVs(cmk.ID)
+	cmIDAttrSet := attribute.NewSet(cmIDAttrs...)
+	w.aggregator.metrics.RequestsTotal.Add(ctx, 1, metric.WithAttributeSet(cmIDAttrSet))
+	w.aggregator.metrics.BytesIngested.Add(ctx, int64(bytesIn), metric.WithAttributeSet(cmIDAttrSet))
+	if err != nil {
+		w.aggregator.metrics.RequestsFailed.Add(ctx, 1, metric.WithAttributeSet(cmIDAttrSet))
+	}
+	return err
+}
+
+// writeCombinedMetrics writes combined metrics for a given key and returns
+// number of bytes ingested along with the error, if any.
+func (w *Writer) writeCombinedMetrics(
+	ctx context.Context,
+	cmk CombinedMetricsKey,
+	cm *aggregationpb.CombinedMetrics,
+) (_ int, resultErr error) {
+
+	// We conditionally commit and close the batch if it is large enough after writing.
+	// We do this after releasing the lock to avoid holding up other writers or readers.
+	var commitBatch *pebble.Batch
+	defer func() {
+		if commitBatch == nil {
+			return
+		}
+		resultErr = errors.Join(
+			resultErr,
+			commitBatch.Commit(w.aggregator.writeOptions),
+			commitBatch.Close(),
+		)
+	}()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.batch == nil {
+		return 0, ErrWriterClosed
+	}
+
+	valueSize := cm.SizeVT()
+	op := w.batch.MergeDeferred(cmk.SizeBinary(), valueSize)
+	if err := cmk.MarshalBinaryToSizedBuffer(op.Key); err != nil {
+		return 0, fmt.Errorf("failed to marshal combined metrics key: %w", err)
+	}
+	if _, err := cm.MarshalToSizedBufferVT(op.Value); err != nil {
+		return 0, fmt.Errorf("failed to marshal combined metrics: %w", err)
+	}
+	if err := op.Finish(); err != nil {
+		return 0, fmt.Errorf("failed to finalize merge operation: %w", err)
+	}
+	if w.batch.Len() >= dbCommitThresholdBytes {
+		commitBatch = w.batch
+		w.batch = w.aggregator.db.NewBatch()
+	}
+	return valueSize, nil
+}


### PR DESCRIPTION
Introduce a Writer type, which encapsulates a pebble.Batch and has methods for writing metrics to the batch. Splitting this out of the Aggregator type enables clients to create independent Writers which are bound to an execution context, to naturally avoid lock contention.

AggregateBatch is now known as WriteEventMetrics, and AggregateCombinedMetrics is now known as WriteCombinedMetrics. We remove tracing from WriteCombinedMetrics, to bring it closer in line with WriteEventMetrics; the cost of tracing at this level is too great.

Replace Aggregator.Stop with Aggregator.Close, which should always be called, even if periodic harvesting is never started.

Replace Aggregator.Run with Aggregator.StartHarvesting, which starts the harvest loop in the background with no context; it will be stopped by Aggregator.Close.

Move cachedEventsMap to its own file.

```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics     
                            │ /tmp/main.txt │             /tmp/pr.txt             │
                            │    sec/op     │    sec/op     vs base               │
AggregateCombinedMetrics       8.631µ ±  4%   7.353µ ±  3%  -14.81% (p=0.002 n=6)
AggregateCombinedMetrics-8     7.252µ ±  8%   8.148µ ±  1%  +12.36% (p=0.002 n=6)
AggregateCombinedMetrics-16    7.312µ ±  9%   8.415µ ±  8%  +15.08% (p=0.004 n=6)
AggregateBatchSerial           22.09µ ±  9%   19.72µ ±  4%  -10.72% (p=0.002 n=6)
AggregateBatchSerial-8         19.45µ ±  7%   16.10µ ±  9%  -17.21% (p=0.002 n=6)
AggregateBatchSerial-16        19.00µ ±  9%   17.04µ ± 14%  -10.33% (p=0.002 n=6)
AggregateBatchParallel         21.59µ ±  3%   22.09µ ± 10%        ~ (p=0.065 n=6)
AggregateBatchParallel-8       23.40µ ± 12%   17.14µ ±  5%  -26.78% (p=0.002 n=6)
AggregateBatchParallel-16      24.74µ ± 18%   17.42µ ±  7%  -29.58% (p=0.002 n=6)
geomean                        15.33µ         13.79µ        -10.06%

                            │ /tmp/main.txt │             /tmp/pr.txt              │
                            │     B/op      │     B/op       vs base               │
AggregateCombinedMetrics       4.772Ki ± 6%   4.449Ki ±  2%   -6.76% (p=0.004 n=6)
AggregateCombinedMetrics-8     4.732Ki ± 9%   4.458Ki ±  1%        ~ (p=0.368 n=6)
AggregateCombinedMetrics-16    4.585Ki ± 7%   4.461Ki ±  2%        ~ (p=0.589 n=6)
AggregateBatchSerial          11.455Ki ± 3%   9.687Ki ± 10%  -15.44% (p=0.002 n=6)
AggregateBatchSerial-8        11.534Ki ± 2%   8.792Ki ±  9%  -23.77% (p=0.002 n=6)
AggregateBatchSerial-16       11.544Ki ± 1%   8.771Ki ± 12%  -24.03% (p=0.002 n=6)
AggregateBatchParallel         11.53Ki ± 2%   11.07Ki ±  4%   -3.96% (p=0.002 n=6)
AggregateBatchParallel-8       11.51Ki ± 1%   10.90Ki ±  8%   -5.32% (p=0.009 n=6)
AggregateBatchParallel-16      11.54Ki ± 2%   10.58Ki ±  5%   -8.31% (p=0.002 n=6)
geomean                        8.541Ki        7.598Ki        -11.04%

                            │ /tmp/main.txt │            /tmp/pr.txt            │
                            │   allocs/op   │ allocs/op   vs base               │
AggregateCombinedMetrics         38.00 ± 5%   29.00 ± 3%  -23.68% (p=0.002 n=6)
AggregateCombinedMetrics-8       38.00 ± 8%   29.00 ± 3%  -23.68% (p=0.002 n=6)
AggregateCombinedMetrics-16      37.00 ± 5%   29.00 ± 3%  -21.62% (p=0.002 n=6)
AggregateBatchSerial             79.00 ± 4%   68.50 ± 8%  -13.29% (p=0.002 n=6)
AggregateBatchSerial-8           79.00 ± 3%   63.00 ± 8%  -20.25% (p=0.002 n=6)
AggregateBatchSerial-16          79.00 ± 1%   63.00 ± 8%  -20.25% (p=0.002 n=6)
AggregateBatchParallel           79.00 ± 3%   76.00 ± 3%   -3.80% (p=0.009 n=6)
AggregateBatchParallel-8         79.00 ± 0%   75.00 ± 5%   -5.06% (p=0.002 n=6)
AggregateBatchParallel-16        79.00 ± 0%   75.00 ± 0%   -5.06% (p=0.002 n=6)
geomean                          61.72        52.11       -15.56%
```