### PR TITLE
Nil out the slices to reduce alloc

### DIFF
--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -920,9 +920,10 @@ func (c combinedMetricsCollector) add(
 	to.SpanMetrics = mergeSlices[aggregationpb.KeyedSpanMetrics](
 		to.SpanMetrics, from.SpanMetrics,
 	)
-	from.ServiceTransactionMetrics = nil
-	from.TransactionMetrics = nil
-	from.SpanMetrics = nil
+	// nil out the slices to avoid ReturnToVTPool from releasing the underlying metrics in the slices
+	nilSlice(from.ServiceTransactionMetrics)
+	nilSlice(from.TransactionMetrics)
+	nilSlice(from.SpanMetrics)
 	from.ReturnToVTPool()
 }
 
@@ -932,4 +933,10 @@ func mergeSlices[T any](to []*T, from []*T) []*T {
 	}
 	to = slices.Grow(to, len(from))
 	return append(to, from...)
+}
+
+func nilSlice[T any](s []*T) {
+	for i := 0; i < len(s); i++ {
+		s[i] = nil
+	}
 }


### PR DESCRIPTION
benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                            │ bench-out/converter-nil-slices-before │ bench-out/converter-nil-slices-after │
                            │                sec/op                 │    sec/op      vs base               │
AggregateCombinedMetrics-16                            4.076µ ± 36%     4.056µ ± 2%       ~ (p=0.516 n=10)
AggregateBatchSerial-16                                10.32µ ±  2%     10.09µ ± 3%       ~ (p=0.123 n=10)
AggregateBatchParallel-16                              10.94µ ± 14%     10.60µ ± 5%       ~ (p=0.393 n=10)
CombinedMetricsEncoding-16                             5.144µ ±  4%     4.999µ ± 2%  -2.82% (p=0.027 n=10)
CombinedMetricsDecoding-16                             4.494µ ±  5%     4.470µ ± 2%       ~ (p=0.149 n=10)
CombinedMetricsToBatch-16                              415.0µ ±  5%     415.5µ ± 2%       ~ (p=0.853 n=10)
EventToCombinedMetrics-16                              879.1n ±  2%     816.0n ± 4%  -7.17% (p=0.001 n=10)
geomean                                                8.735µ           8.531µ       -2.34%

                            │ bench-out/converter-nil-slices-before │   bench-out/converter-nil-slices-after    │
                            │                 B/op                  │     B/op      vs base                     │
AggregateCombinedMetrics-16                          4.824Ki ± 3%     4.894Ki ± 2%         ~ (p=0.403 n=10)
AggregateBatchSerial-16                              11.37Ki ± 0%     11.30Ki ± 1%    -0.62% (p=0.007 n=10)
AggregateBatchParallel-16                            11.31Ki ± 1%     11.31Ki ± 1%         ~ (p=0.542 n=10)
CombinedMetricsEncoding-16                             0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10)
CombinedMetricsDecoding-16                           10.01Ki ± 0%     10.01Ki ± 0%         ~ (p=0.170 n=10)
CombinedMetricsToBatch-16                            37.66Ki ± 0%     37.66Ki ± 0%         ~ (p=1.000 n=10) ¹
EventToCombinedMetrics-16                              16.00 ± 0%        0.00 ± 0%  -100.00% (p=0.000 n=10)
geomean                                                           ²                 ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                            │ bench-out/converter-nil-slices-before │  bench-out/converter-nil-slices-after   │
                            │               allocs/op               │ allocs/op   vs base                     │
AggregateCombinedMetrics-16                            38.50 ± 1%     39.00 ± 3%         ~ (p=1.000 n=10)
AggregateBatchSerial-16                                67.00 ± 0%     61.00 ± 0%    -8.96% (p=0.000 n=10)
AggregateBatchParallel-16                              67.00 ± 0%     61.00 ± 0%    -8.96% (p=0.000 n=10)
CombinedMetricsEncoding-16                             0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
CombinedMetricsDecoding-16                             40.00 ± 0%     40.00 ± 0%         ~ (p=1.000 n=10) ¹
CombinedMetricsToBatch-16                              308.0 ± 0%     308.0 ± 0%         ~ (p=1.000 n=10) ¹
EventToCombinedMetrics-16                              2.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                                                           ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```