### PR TITLE
Remove FromProto and hide most non-proto structs

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -76,9 +76,12 @@ func New(opts ...Option) (*Aggregator, error) {
 				merger := combinedMetricsMerger{
 					limits: cfg.Limits,
 				}
-				if err := merger.metrics.UnmarshalBinary(value); err != nil {
-					return nil, err
+				pb := aggregationpb.CombinedMetricsFromVTPool()
+				defer pb.ReturnToVTPool()
+				if err := pb.UnmarshalVT(value); err != nil {
+					return nil, fmt.Errorf("failed to unmarshal metrics: %w", err)
 				}
+				merger.merge(pb)
 				return &merger, nil
 			},
 		},

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -176,26 +176,26 @@ func TestAggregateBatch(t *testing.T) {
 			},
 		},
 	}
-	sik := ServiceInstanceAggregationKey{GlobalLabelsStr: ""}
+	sik := serviceInstanceAggregationKey{GlobalLabelsStr: ""}
 	for i := 0; i < uniqueEventCount*repCount; i++ {
-		svcKey := ServiceAggregationKey{
+		svcKey := serviceAggregationKey{
 			Timestamp:   time.Unix(0, 0).UTC(),
 			ServiceName: fmt.Sprintf("svc%d", i%uniqueServices),
 		}
-		txKey := TransactionAggregationKey{
+		txKey := transactionAggregationKey{
 			TraceRoot:       true,
 			TransactionName: fmt.Sprintf("foo%d", i%uniqueEventCount),
 			TransactionType: fmt.Sprintf("txtype%d", i%uniqueEventCount),
 			EventOutcome:    "success",
 		}
-		stxKey := ServiceTransactionAggregationKey{
+		stxKey := serviceTransactionAggregationKey{
 			TransactionType: fmt.Sprintf("txtype%d", i%uniqueEventCount),
 		}
-		spanKey := SpanAggregationKey{
+		spanKey := spanAggregationKey{
 			SpanName: fmt.Sprintf("bar%d", i%uniqueEventCount),
 			Resource: "test_dest",
 		}
-		dssKey := SpanAggregationKey{
+		dssKey := spanAggregationKey{
 			SpanName: "",
 			Resource: fmt.Sprintf("dropped_dest_resource%d", i%uniqueEventCount),
 			Outcome:  "success",
@@ -1102,16 +1102,16 @@ func BenchmarkAggregateCombinedMetrics(b *testing.B) {
 		ID:             EncodeToCombinedMetricsKeyID(b, "ab01"),
 	}
 	cm := NewTestCombinedMetrics(WithEventsTotal(1)).
-		AddServiceMetrics(ServiceAggregationKey{
+		AddServiceMetrics(serviceAggregationKey{
 			Timestamp:   time.Now(),
 			ServiceName: "test-svc",
 		}).
-		AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-		AddTransaction(TransactionAggregationKey{
+		AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+		AddTransaction(transactionAggregationKey{
 			TransactionName: "txntest",
 			TransactionType: "txntype",
 		}).
-		AddServiceTransaction(ServiceTransactionAggregationKey{
+		AddServiceTransaction(serviceTransactionAggregationKey{
 			TransactionType: "txntype",
 		}).
 		GetProto()

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -80,7 +80,7 @@ func (k *CombinedMetricsKey) SizeBinary() int {
 }
 
 // ToProto converts CombinedMetrics to its protobuf representation.
-func (m *CombinedMetrics) ToProto() *aggregationpb.CombinedMetrics {
+func (m *combinedMetrics) ToProto() *aggregationpb.CombinedMetrics {
 	pb := aggregationpb.CombinedMetricsFromVTPool()
 	if len(m.Services) > cap(pb.ServiceMetrics) {
 		pb.ServiceMetrics = make([]*aggregationpb.KeyedServiceMetrics, 0, len(m.Services))
@@ -103,14 +103,14 @@ func (m *CombinedMetrics) ToProto() *aggregationpb.CombinedMetrics {
 // MarshalBinary marshals CombinedMetrics to binary using protobuf.
 // This should be the last call for the CombinedMetrics and all
 // proto resources of CombinedMetrics will be released in this call.
-func (m *CombinedMetrics) MarshalBinary() ([]byte, error) {
+func (m *combinedMetrics) MarshalBinary() ([]byte, error) {
 	pb := m.ToProto()
 	defer pb.ReturnToVTPool()
 	return pb.MarshalVT()
 }
 
 // ToProto converts ServiceAggregationKey to its protobuf representation.
-func (k *ServiceAggregationKey) ToProto() *aggregationpb.ServiceAggregationKey {
+func (k *serviceAggregationKey) ToProto() *aggregationpb.ServiceAggregationKey {
 	pb := aggregationpb.ServiceAggregationKeyFromVTPool()
 	pb.Timestamp = timestamppb.TimeToPBTimestamp(k.Timestamp)
 	pb.ServiceName = k.ServiceName
@@ -121,7 +121,7 @@ func (k *ServiceAggregationKey) ToProto() *aggregationpb.ServiceAggregationKey {
 }
 
 // FromProto converts protobuf representation to ServiceAggregationKey.
-func (k *ServiceAggregationKey) FromProto(pb *aggregationpb.ServiceAggregationKey) {
+func (k *serviceAggregationKey) FromProto(pb *aggregationpb.ServiceAggregationKey) {
 	k.Timestamp = timestamppb.PBTimestampToTime(pb.Timestamp)
 	k.ServiceName = pb.ServiceName
 	k.ServiceEnvironment = pb.ServiceEnvironment
@@ -130,7 +130,7 @@ func (k *ServiceAggregationKey) FromProto(pb *aggregationpb.ServiceAggregationKe
 }
 
 // ToProto converts ServiceMetrics to its protobuf representation.
-func (m *ServiceMetrics) ToProto() *aggregationpb.ServiceMetrics {
+func (m *serviceMetrics) ToProto() *aggregationpb.ServiceMetrics {
 	pb := aggregationpb.ServiceMetricsFromVTPool()
 	if len(m.ServiceInstanceGroups) > cap(pb.ServiceInstanceMetrics) {
 		pb.ServiceInstanceMetrics = make([]*aggregationpb.KeyedServiceInstanceMetrics, 0, len(m.ServiceInstanceGroups))
@@ -146,19 +146,19 @@ func (m *ServiceMetrics) ToProto() *aggregationpb.ServiceMetrics {
 }
 
 // ToProto converts ServiceInstanceAggregationKey to its protobuf representation.
-func (k *ServiceInstanceAggregationKey) ToProto() *aggregationpb.ServiceInstanceAggregationKey {
+func (k *serviceInstanceAggregationKey) ToProto() *aggregationpb.ServiceInstanceAggregationKey {
 	pb := aggregationpb.ServiceInstanceAggregationKeyFromVTPool()
 	pb.GlobalLabelsStr = []byte(k.GlobalLabelsStr)
 	return pb
 }
 
 // FromProto converts protobuf representation to ServiceInstanceAggregationKey.
-func (k *ServiceInstanceAggregationKey) FromProto(pb *aggregationpb.ServiceInstanceAggregationKey) {
+func (k *serviceInstanceAggregationKey) FromProto(pb *aggregationpb.ServiceInstanceAggregationKey) {
 	k.GlobalLabelsStr = string(pb.GlobalLabelsStr)
 }
 
 // ToProto converts ServiceInstanceMetrics to its protobuf representation.
-func (m *ServiceInstanceMetrics) ToProto() *aggregationpb.ServiceInstanceMetrics {
+func (m *serviceInstanceMetrics) ToProto() *aggregationpb.ServiceInstanceMetrics {
 	pb := aggregationpb.ServiceInstanceMetricsFromVTPool()
 	if len(m.TransactionGroups) > cap(pb.TransactionMetrics) {
 		pb.TransactionMetrics = make([]*aggregationpb.KeyedTransactionMetrics, 0, len(m.TransactionGroups))
@@ -182,7 +182,7 @@ func (m *ServiceInstanceMetrics) ToProto() *aggregationpb.ServiceInstanceMetrics
 }
 
 // ToProto converts TransactionAggregationKey to its protobuf representation.
-func (k *TransactionAggregationKey) ToProto() *aggregationpb.TransactionAggregationKey {
+func (k *transactionAggregationKey) ToProto() *aggregationpb.TransactionAggregationKey {
 	pb := aggregationpb.TransactionAggregationKeyFromVTPool()
 	pb.TraceRoot = k.TraceRoot
 
@@ -225,7 +225,7 @@ func (k *TransactionAggregationKey) ToProto() *aggregationpb.TransactionAggregat
 }
 
 // FromProto converts protobuf representation to TransactionAggregationKey.
-func (k *TransactionAggregationKey) FromProto(pb *aggregationpb.TransactionAggregationKey) {
+func (k *transactionAggregationKey) FromProto(pb *aggregationpb.TransactionAggregationKey) {
 	k.TraceRoot = pb.TraceRoot
 
 	k.ContainerID = pb.ContainerId
@@ -266,59 +266,19 @@ func (k *TransactionAggregationKey) FromProto(pb *aggregationpb.TransactionAggre
 }
 
 // ToProto converts ServiceTransactionAggregationKey to its protobuf representation.
-func (k *ServiceTransactionAggregationKey) ToProto() *aggregationpb.ServiceTransactionAggregationKey {
+func (k *serviceTransactionAggregationKey) ToProto() *aggregationpb.ServiceTransactionAggregationKey {
 	pb := aggregationpb.ServiceTransactionAggregationKeyFromVTPool()
 	pb.TransactionType = k.TransactionType
 	return pb
 }
 
 // FromProto converts protobuf representation to ServiceTransactionAggregationKey.
-func (k *ServiceTransactionAggregationKey) FromProto(pb *aggregationpb.ServiceTransactionAggregationKey) {
+func (k *serviceTransactionAggregationKey) FromProto(pb *aggregationpb.ServiceTransactionAggregationKey) {
 	k.TransactionType = pb.TransactionType
 }
 
-// HistogramToProto converts the histogram representation to protobuf.
-func HistogramToProto(h *hdrhistogram.HistogramRepresentation) *aggregationpb.HDRHistogram {
-	if h == nil {
-		return nil
-	}
-	pb := aggregationpb.HDRHistogramFromVTPool()
-	pb.LowestTrackableValue = h.LowestTrackableValue
-	pb.HighestTrackableValue = h.HighestTrackableValue
-	pb.SignificantFigures = h.SignificantFigures
-	countsLen := h.CountsRep.Len()
-	if countsLen > cap(pb.Buckets) {
-		pb.Buckets = make([]int32, 0, countsLen)
-	}
-	if countsLen > cap(pb.Counts) {
-		pb.Counts = make([]int64, 0, countsLen)
-	}
-	h.CountsRep.ForEach(func(bucket int32, value int64) {
-		pb.Buckets = append(pb.Buckets, bucket)
-		pb.Counts = append(pb.Counts, value)
-	})
-	return pb
-}
-
-// HistogramFromProto converts protobuf to histogram representation.
-func HistogramFromProto(h *hdrhistogram.HistogramRepresentation, pb *aggregationpb.HDRHistogram) {
-	if pb == nil {
-		return
-	}
-	h.LowestTrackableValue = pb.LowestTrackableValue
-	h.HighestTrackableValue = pb.HighestTrackableValue
-	h.SignificantFigures = pb.SignificantFigures
-	h.CountsRep.Reset()
-
-	for i := 0; i < len(pb.Buckets); i++ {
-		bucket := pb.Buckets[i]
-		counts := pb.Counts[i]
-		h.CountsRep.Add(bucket, counts)
-	}
-}
-
 // ToProto converts SpanAggregationKey to its protobuf representation.
-func (k *SpanAggregationKey) ToProto() *aggregationpb.SpanAggregationKey {
+func (k *spanAggregationKey) ToProto() *aggregationpb.SpanAggregationKey {
 	pb := aggregationpb.SpanAggregationKeyFromVTPool()
 	pb.SpanName = k.SpanName
 	pb.Outcome = k.Outcome
@@ -331,7 +291,7 @@ func (k *SpanAggregationKey) ToProto() *aggregationpb.SpanAggregationKey {
 }
 
 // FromProto converts protobuf representation to SpanAggregationKey.
-func (k *SpanAggregationKey) FromProto(pb *aggregationpb.SpanAggregationKey) {
+func (k *spanAggregationKey) FromProto(pb *aggregationpb.SpanAggregationKey) {
 	k.SpanName = pb.SpanName
 	k.Outcome = pb.Outcome
 
@@ -342,7 +302,7 @@ func (k *SpanAggregationKey) FromProto(pb *aggregationpb.SpanAggregationKey) {
 }
 
 // ToProto converts Overflow to its protobuf representation.
-func (o *Overflow) ToProto() *aggregationpb.Overflow {
+func (o *overflow) ToProto() *aggregationpb.Overflow {
 	pb := aggregationpb.OverflowFromVTPool()
 	if !o.OverflowTransaction.Empty() {
 		pb.OverflowTransactions = o.OverflowTransaction.Metrics
@@ -360,7 +320,7 @@ func (o *Overflow) ToProto() *aggregationpb.Overflow {
 }
 
 // FromProto converts protobuf representation to Overflow.
-func (o *Overflow) FromProto(pb *aggregationpb.Overflow) {
+func (o *overflow) FromProto(pb *aggregationpb.Overflow) {
 	if pb.OverflowTransactions != nil {
 		o.OverflowTransaction.Estimator = hllSketch(pb.OverflowTransactionsEstimator)
 		o.OverflowTransaction.Metrics = pb.OverflowTransactions
@@ -464,6 +424,44 @@ func (gl *GlobalLabels) UnmarshalBinary(data []byte) error {
 // UnmarshalString unmarshals string of binary protobuf to GlobalLabels.
 func (gl *GlobalLabels) UnmarshalString(data string) error {
 	return gl.UnmarshalBinary([]byte(data))
+}
+
+func histogramFromProto(h *hdrhistogram.HistogramRepresentation, pb *aggregationpb.HDRHistogram) {
+	if pb == nil {
+		return
+	}
+	h.LowestTrackableValue = pb.LowestTrackableValue
+	h.HighestTrackableValue = pb.HighestTrackableValue
+	h.SignificantFigures = pb.SignificantFigures
+	h.CountsRep.Reset()
+
+	for i := 0; i < len(pb.Buckets); i++ {
+		bucket := pb.Buckets[i]
+		counts := pb.Counts[i]
+		h.CountsRep.Add(bucket, counts)
+	}
+}
+
+func histogramToProto(h *hdrhistogram.HistogramRepresentation) *aggregationpb.HDRHistogram {
+	if h == nil {
+		return nil
+	}
+	pb := aggregationpb.HDRHistogramFromVTPool()
+	pb.LowestTrackableValue = h.LowestTrackableValue
+	pb.HighestTrackableValue = h.HighestTrackableValue
+	pb.SignificantFigures = h.SignificantFigures
+	countsLen := h.CountsRep.Len()
+	if countsLen > cap(pb.Buckets) {
+		pb.Buckets = make([]int32, 0, countsLen)
+	}
+	if countsLen > cap(pb.Counts) {
+		pb.Counts = make([]int64, 0, countsLen)
+	}
+	h.CountsRep.ForEach(func(bucket int32, value int64) {
+		pb.Buckets = append(pb.Buckets, bucket)
+		pb.Counts = append(pb.Counts, value)
+	})
+	return pb
 }
 
 func hllBytes(estimator *hyperloglog.Sketch) []byte {

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -119,6 +119,8 @@ func (m *CombinedMetrics) FromProto(pb *aggregationpb.CombinedMetrics) {
 }
 
 // MarshalBinary marshals CombinedMetrics to binary using protobuf.
+// This should be the last call for the CombinedMetrics and all
+// proto resources of CombinedMetrics will be released in this call.
 func (m *CombinedMetrics) MarshalBinary() ([]byte, error) {
 	pb := m.ToProto()
 	defer pb.ReturnToVTPool()

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -100,15 +100,6 @@ func (m *combinedMetrics) ToProto() *aggregationpb.CombinedMetrics {
 	return pb
 }
 
-// MarshalBinary marshals CombinedMetrics to binary using protobuf.
-// This should be the last call for the CombinedMetrics and all
-// proto resources of CombinedMetrics will be released in this call.
-func (m *combinedMetrics) MarshalBinary() ([]byte, error) {
-	pb := m.ToProto()
-	defer pb.ReturnToVTPool()
-	return pb.MarshalVT()
-}
-
 // ToProto converts ServiceAggregationKey to its protobuf representation.
 func (k *serviceAggregationKey) ToProto() *aggregationpb.ServiceAggregationKey {
 	pb := aggregationpb.ServiceAggregationKeyFromVTPool()

--- a/aggregators/codec_test.go
+++ b/aggregators/codec_test.go
@@ -63,7 +63,7 @@ func TestHistogramRepresentation(t *testing.T) {
 	expected.RecordDuration(time.Minute, 2)
 
 	actual := hdrhistogram.New()
-	HistogramFromProto(actual, HistogramToProto(expected))
+	histogramFromProto(actual, histogramToProto(expected))
 	assert.Empty(t, cmp.Diff(
 		expected, actual,
 		cmp.Comparer(func(a, b hdrhistogram.HybridCountsRep) bool {
@@ -77,23 +77,23 @@ func BenchmarkCombinedMetricsEncoding(b *testing.B) {
 	ts := time.Now()
 	cardinality := 10
 	tcm := NewTestCombinedMetrics()
-	sim := tcm.AddServiceMetrics(ServiceAggregationKey{
+	sim := tcm.AddServiceMetrics(serviceAggregationKey{
 		Timestamp:   ts,
 		ServiceName: "bench",
-	}).AddServiceInstanceMetrics(ServiceInstanceAggregationKey{})
+	}).AddServiceInstanceMetrics(serviceInstanceAggregationKey{})
 	for i := 0; i < cardinality; i++ {
 		txnName := fmt.Sprintf("txn%d", i)
 		txnType := fmt.Sprintf("typ%d", i)
 		spanName := fmt.Sprintf("spn%d", i)
 
-		sim.AddTransaction(TransactionAggregationKey{
+		sim.AddTransaction(transactionAggregationKey{
 			TransactionName: txnName,
 			TransactionType: txnType,
 		}, WithTransactionCount(200))
-		sim.AddServiceTransaction(ServiceTransactionAggregationKey{
+		sim.AddServiceTransaction(serviceTransactionAggregationKey{
 			TransactionType: txnType,
 		}, WithTransactionCount(200))
-		sim.AddSpan(SpanAggregationKey{
+		sim.AddSpan(spanAggregationKey{
 			SpanName: spanName,
 		})
 	}

--- a/aggregators/codec_test.go
+++ b/aggregators/codec_test.go
@@ -105,42 +105,6 @@ func BenchmarkCombinedMetricsEncoding(b *testing.B) {
 	}
 }
 
-func BenchmarkCombinedMetricsDecoding(b *testing.B) {
-	b.ReportAllocs()
-	ts := time.Now()
-	cardinality := 10
-	tcm := NewTestCombinedMetrics()
-	sim := tcm.AddServiceMetrics(ServiceAggregationKey{
-		Timestamp:   ts,
-		ServiceName: "bench",
-	}).AddServiceInstanceMetrics(ServiceInstanceAggregationKey{})
-	for i := 0; i < cardinality; i++ {
-		txnName := fmt.Sprintf("txn%d", i)
-		txnType := fmt.Sprintf("typ%d", i)
-		spanName := fmt.Sprintf("spn%d", i)
-
-		sim.AddTransaction(TransactionAggregationKey{
-			TransactionName: txnName,
-			TransactionType: txnType,
-		}, WithTransactionCount(200))
-		sim.AddServiceTransaction(ServiceTransactionAggregationKey{
-			TransactionType: txnType,
-		}, WithTransactionCount(200))
-		sim.AddSpan(SpanAggregationKey{
-			SpanName: spanName,
-		})
-	}
-	cmproto := tcm.GetProto()
-	b.Cleanup(func() {
-		cmproto.ReturnToVTPool()
-	})
-	b.ResetTimer()
-	var expected CombinedMetrics
-	for i := 0; i < b.N; i++ {
-		expected.FromProto(cmproto)
-	}
-}
-
 func EncodeToCombinedMetricsKeyID(tb testing.TB, s string) [16]byte {
 	var b [16]byte
 	if len(s) > len(b) {

--- a/aggregators/combined_metrics_test.go
+++ b/aggregators/combined_metrics_test.go
@@ -38,7 +38,7 @@ func WithYoungestEventTimestamp(ts time.Time) TestCombinedMetricsOpt {
 
 var defaultTestCombinedMetricsCfg = TestCombinedMetricsCfg{
 	eventsTotal:            1,
-	youngestEventTimestamp: time.Time{},
+	youngestEventTimestamp: time.Unix(0, 0).UTC(),
 }
 
 type TestTransactionCfg struct {
@@ -188,14 +188,6 @@ func (tsm *TestServiceMetrics) AddServiceInstanceMetricsOverflow(
 		tsm:      tsm,
 		overflow: true,
 	}
-}
-
-func (tsim *TestServiceInstanceMetrics) GetProto() *aggregationpb.CombinedMetrics {
-	return tsim.tsm.tcm.GetProto()
-}
-
-func (tsim *TestServiceInstanceMetrics) Get() CombinedMetrics {
-	return tsim.tsm.tcm.Get()
 }
 
 func (tsim *TestServiceInstanceMetrics) AddTransaction(
@@ -370,6 +362,14 @@ func (tsim *TestServiceInstanceMetrics) AddSpanOverflow(
 		tsim.tsm.tcm.Services[tsim.tsm.sk] = svc
 	}
 	return tsim
+}
+
+func (tsim *TestServiceInstanceMetrics) GetProto() *aggregationpb.CombinedMetrics {
+	return tsim.tsm.tcm.GetProto()
+}
+
+func (tsim *TestServiceInstanceMetrics) Get() CombinedMetrics {
+	return tsim.tsm.tcm.Get()
 }
 
 // Set of cmp options to sort combined metrics based on key hash. Hash collisions

--- a/aggregators/combined_metrics_test.go
+++ b/aggregators/combined_metrics_test.go
@@ -96,39 +96,39 @@ var defaultTestSpanCfg = TestSpanCfg{
 // TestCombinedMetrics creates combined metrics for testing. The creation logic
 // is arranged in a way to allow chained creation and addition of leaf nodes
 // to combined metrics.
-type TestCombinedMetrics CombinedMetrics
+type TestCombinedMetrics combinedMetrics
 
 func NewTestCombinedMetrics(opts ...TestCombinedMetricsOpt) *TestCombinedMetrics {
 	cfg := defaultTestCombinedMetricsCfg
 	for _, opt := range opts {
 		cfg = opt(cfg)
 	}
-	var cm CombinedMetrics
+	var cm combinedMetrics
 	cm.EventsTotal = cfg.eventsTotal
 	cm.YoungestEventTimestamp = timestamppb.TimeToPBTimestamp(cfg.youngestEventTimestamp)
-	cm.Services = make(map[ServiceAggregationKey]ServiceMetrics)
+	cm.Services = make(map[serviceAggregationKey]serviceMetrics)
 	return (*TestCombinedMetrics)(&cm)
 }
 
 func (tcm *TestCombinedMetrics) GetProto() *aggregationpb.CombinedMetrics {
-	cm := (*CombinedMetrics)(tcm)
+	cm := (*combinedMetrics)(tcm)
 	cmproto := cm.ToProto()
 	return cmproto
 }
 
-func (tcm *TestCombinedMetrics) Get() CombinedMetrics {
-	cm := (*CombinedMetrics)(tcm)
+func (tcm *TestCombinedMetrics) Get() combinedMetrics {
+	cm := (*combinedMetrics)(tcm)
 	return *cm
 }
 
 type TestServiceMetrics struct {
-	sk       ServiceAggregationKey
+	sk       serviceAggregationKey
 	tcm      *TestCombinedMetrics
 	overflow bool // indicates if the service has overflowed to global
 }
 
 func (tcm *TestCombinedMetrics) AddServiceMetrics(
-	sk ServiceAggregationKey,
+	sk serviceAggregationKey,
 ) *TestServiceMetrics {
 	if _, ok := tcm.Services[sk]; !ok {
 		tcm.Services[sk] = newServiceMetrics()
@@ -137,7 +137,7 @@ func (tcm *TestCombinedMetrics) AddServiceMetrics(
 }
 
 func (tcm *TestCombinedMetrics) AddServiceMetricsOverflow(
-	sk ServiceAggregationKey,
+	sk serviceAggregationKey,
 ) *TestServiceMetrics {
 	if _, ok := tcm.Services[sk]; ok {
 		panic("service already added as non overflow")
@@ -148,13 +148,13 @@ func (tcm *TestCombinedMetrics) AddServiceMetricsOverflow(
 }
 
 type TestServiceInstanceMetrics struct {
-	sik      ServiceInstanceAggregationKey
+	sik      serviceInstanceAggregationKey
 	tsm      *TestServiceMetrics
 	overflow bool // indicates if the service instance has overflowed to global
 }
 
 func (tsm *TestServiceMetrics) AddServiceInstanceMetrics(
-	sik ServiceInstanceAggregationKey,
+	sik serviceInstanceAggregationKey,
 ) *TestServiceInstanceMetrics {
 	svc := tsm.tcm.Services[tsm.sk]
 	if _, ok := svc.ServiceInstanceGroups[sik]; !ok {
@@ -167,7 +167,7 @@ func (tsm *TestServiceMetrics) AddServiceInstanceMetrics(
 }
 
 func (tsm *TestServiceMetrics) AddServiceInstanceMetricsOverflow(
-	sik ServiceInstanceAggregationKey,
+	sik serviceInstanceAggregationKey,
 ) *TestServiceInstanceMetrics {
 	if !tsm.overflow {
 		svc := tsm.tcm.Services[tsm.sk]
@@ -191,7 +191,7 @@ func (tsm *TestServiceMetrics) AddServiceInstanceMetricsOverflow(
 }
 
 func (tsim *TestServiceInstanceMetrics) AddTransaction(
-	tk TransactionAggregationKey,
+	tk transactionAggregationKey,
 	opts ...TestTransactionOpt,
 ) *TestServiceInstanceMetrics {
 	if tsim.overflow {
@@ -207,7 +207,7 @@ func (tsim *TestServiceInstanceMetrics) AddTransaction(
 	ktm := aggregationpb.KeyedTransactionMetricsFromVTPool()
 	ktm.Key = tk.ToProto()
 	ktm.Metrics = aggregationpb.TransactionMetricsFromVTPool()
-	ktm.Metrics.Histogram = HistogramToProto(hdr)
+	ktm.Metrics.Histogram = histogramToProto(hdr)
 
 	svc := tsim.tsm.tcm.Services[tsim.tsm.sk]
 	svcIns := svc.ServiceInstanceGroups[tsim.sik]
@@ -220,7 +220,7 @@ func (tsim *TestServiceInstanceMetrics) AddTransaction(
 }
 
 func (tsim *TestServiceInstanceMetrics) AddTransactionOverflow(
-	tk TransactionAggregationKey,
+	tk transactionAggregationKey,
 	opts ...TestTransactionOpt,
 ) *TestServiceInstanceMetrics {
 	cfg := defaultTestTransactionCfg
@@ -231,7 +231,7 @@ func (tsim *TestServiceInstanceMetrics) AddTransactionOverflow(
 	hdr := hdrhistogram.New()
 	hdr.RecordDuration(cfg.duration, float64(cfg.count))
 	from := aggregationpb.TransactionMetricsFromVTPool()
-	from.Histogram = HistogramToProto(hdr)
+	from.Histogram = histogramToProto(hdr)
 
 	hash := Hasher{}.
 		Chain(tsim.tsm.sk.ToProto()).
@@ -251,7 +251,7 @@ func (tsim *TestServiceInstanceMetrics) AddTransactionOverflow(
 }
 
 func (tsim *TestServiceInstanceMetrics) AddServiceTransaction(
-	stk ServiceTransactionAggregationKey,
+	stk serviceTransactionAggregationKey,
 	opts ...TestTransactionOpt,
 ) *TestServiceInstanceMetrics {
 	cfg := defaultTestTransactionCfg
@@ -264,7 +264,7 @@ func (tsim *TestServiceInstanceMetrics) AddServiceTransaction(
 	kstm := aggregationpb.KeyedServiceTransactionMetricsFromVTPool()
 	kstm.Key = stk.ToProto()
 	kstm.Metrics = aggregationpb.ServiceTransactionMetricsFromVTPool()
-	kstm.Metrics.Histogram = HistogramToProto(hdr)
+	kstm.Metrics.Histogram = histogramToProto(hdr)
 	kstm.Metrics.SuccessCount += float64(cfg.count)
 
 	svc := tsim.tsm.tcm.Services[tsim.tsm.sk]
@@ -278,7 +278,7 @@ func (tsim *TestServiceInstanceMetrics) AddServiceTransaction(
 }
 
 func (tsim *TestServiceInstanceMetrics) AddServiceTransactionOverflow(
-	stk ServiceTransactionAggregationKey,
+	stk serviceTransactionAggregationKey,
 	opts ...TestTransactionOpt,
 ) *TestServiceInstanceMetrics {
 	cfg := defaultTestTransactionCfg
@@ -289,7 +289,7 @@ func (tsim *TestServiceInstanceMetrics) AddServiceTransactionOverflow(
 	hdr := hdrhistogram.New()
 	hdr.RecordDuration(cfg.duration, float64(cfg.count))
 	from := aggregationpb.ServiceTransactionMetricsFromVTPool()
-	from.Histogram = HistogramToProto(hdr)
+	from.Histogram = histogramToProto(hdr)
 	from.SuccessCount += float64(cfg.count)
 
 	hash := Hasher{}.
@@ -310,7 +310,7 @@ func (tsim *TestServiceInstanceMetrics) AddServiceTransactionOverflow(
 }
 
 func (tsim *TestServiceInstanceMetrics) AddSpan(
-	spk SpanAggregationKey,
+	spk spanAggregationKey,
 	opts ...TestSpanOpt,
 ) *TestServiceInstanceMetrics {
 	cfg := defaultTestSpanCfg
@@ -335,7 +335,7 @@ func (tsim *TestServiceInstanceMetrics) AddSpan(
 }
 
 func (tsim *TestServiceInstanceMetrics) AddSpanOverflow(
-	spk SpanAggregationKey,
+	spk spanAggregationKey,
 	opts ...TestSpanOpt,
 ) *TestServiceInstanceMetrics {
 	cfg := defaultTestSpanCfg
@@ -368,7 +368,7 @@ func (tsim *TestServiceInstanceMetrics) GetProto() *aggregationpb.CombinedMetric
 	return tsim.tsm.tcm.GetProto()
 }
 
-func (tsim *TestServiceInstanceMetrics) Get() CombinedMetrics {
+func (tsim *TestServiceInstanceMetrics) Get() combinedMetrics {
 	return tsim.tsm.tcm.Get()
 }
 

--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -323,7 +323,7 @@ func eventToTxnMetrics(
 	*aggregationpb.ServiceInstanceMetrics,
 ) {
 	tm := aggregationpb.TransactionMetricsFromVTPool()
-	tm.Histogram = HistogramToProto(hdr)
+	tm.Histogram = histogramToProto(hdr)
 
 	txnKey := transactionKey(e)
 	ktm := aggregationpb.KeyedTransactionMetricsFromVTPool()
@@ -344,7 +344,7 @@ func eventToServiceTxnMetrics(
 	*aggregationpb.ServiceInstanceMetrics,
 ) {
 	stm := aggregationpb.ServiceTransactionMetricsFromVTPool()
-	stm.Histogram = HistogramToProto(hdr)
+	stm.Histogram = histogramToProto(hdr)
 	setMetricCountBasedOnOutcome(stm, e)
 
 	svcTxnKey := serviceTransactionKey(e)
@@ -445,7 +445,7 @@ func txnMetricsToAPMEvent(
 	intervalStr string,
 ) {
 	histogram := hdrhistogram.New()
-	HistogramFromProto(histogram, metrics.Histogram)
+	histogramFromProto(histogram, metrics.Histogram)
 	totalCount, counts, values := histogram.Buckets()
 	var eventSuccessCount modelpb.SummaryMetric
 	switch key.EventOutcome {
@@ -579,7 +579,7 @@ func svcTxnMetricsToAPMEvent(
 	intervalStr string,
 ) {
 	histogram := hdrhistogram.New()
-	HistogramFromProto(histogram, metrics.Histogram)
+	histogramFromProto(histogram, metrics.Histogram)
 	totalCount, counts, values := histogram.Buckets()
 	transactionDurationSummary := modelpb.SummaryMetric{
 		Count: totalCount,

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -76,16 +76,16 @@ func TestEventToCombinedMetrics(t *testing.T) {
 					NewTestCombinedMetrics(
 						WithEventsTotal(1),
 						WithYoungestEventTimestamp(receivedTS)).
-						AddServiceMetrics(ServiceAggregationKey{
+						AddServiceMetrics(serviceAggregationKey{
 							Timestamp:   ts.Truncate(time.Minute),
 							ServiceName: "test"}).
-						AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-						AddTransaction(TransactionAggregationKey{
+						AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+						AddTransaction(transactionAggregationKey{
 							TransactionName: "testtxn",
 							TransactionType: "testtyp",
 							EventOutcome:    "success",
 						}).
-						AddServiceTransaction(ServiceTransactionAggregationKey{
+						AddServiceTransaction(serviceTransactionAggregationKey{
 							TransactionType: "testtyp",
 						}).GetProto(),
 				}
@@ -146,11 +146,11 @@ func TestEventToCombinedMetrics(t *testing.T) {
 					NewTestCombinedMetrics(
 						WithEventsTotal(1),
 						WithYoungestEventTimestamp(receivedTS)).
-						AddServiceMetrics(ServiceAggregationKey{
+						AddServiceMetrics(serviceAggregationKey{
 							Timestamp:   ts.Truncate(time.Minute),
 							ServiceName: "test"}).
-						AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-						AddSpan(SpanAggregationKey{
+						AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+						AddSpan(spanAggregationKey{
 							SpanName:   "testspan",
 							TargetName: "psql",
 							TargetType: "db",
@@ -181,11 +181,11 @@ func TestEventToCombinedMetrics(t *testing.T) {
 					NewTestCombinedMetrics(
 						WithEventsTotal(1),
 						WithYoungestEventTimestamp(receivedTS)).
-						AddServiceMetrics(ServiceAggregationKey{
+						AddServiceMetrics(serviceAggregationKey{
 							Timestamp:   ts.Truncate(time.Minute),
 							ServiceName: "test"}).
-						AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-						AddSpan(SpanAggregationKey{
+						AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+						AddSpan(spanAggregationKey{
 							SpanName: "testspan",
 							Resource: "db",
 							Outcome:  "success",
@@ -209,10 +209,10 @@ func TestEventToCombinedMetrics(t *testing.T) {
 					NewTestCombinedMetrics(
 						WithEventsTotal(1),
 						WithYoungestEventTimestamp(receivedTS)).
-						AddServiceMetrics(ServiceAggregationKey{
+						AddServiceMetrics(serviceAggregationKey{
 							Timestamp:   ts.Truncate(time.Minute),
 							ServiceName: "test"}).
-						AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
+						AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
 						GetProto(),
 				}
 			},
@@ -230,10 +230,10 @@ func TestEventToCombinedMetrics(t *testing.T) {
 					NewTestCombinedMetrics(
 						WithEventsTotal(1),
 						WithYoungestEventTimestamp(receivedTS)).
-						AddServiceMetrics(ServiceAggregationKey{
+						AddServiceMetrics(serviceAggregationKey{
 							Timestamp:   ts.Truncate(time.Minute),
 							ServiceName: "test"}).
-						AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
+						AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
 						GetProto(),
 				}
 			},
@@ -274,18 +274,18 @@ func TestCombinedMetricsToBatch(t *testing.T) {
 	svcName := "test"
 	coldstart := nullable.True
 	var (
-		svc            = ServiceAggregationKey{Timestamp: ts, ServiceName: svcName}
-		svcIns         = ServiceInstanceAggregationKey{}
+		svc            = serviceAggregationKey{Timestamp: ts, ServiceName: svcName}
+		svcIns         = serviceInstanceAggregationKey{}
 		faas           = &modelpb.Faas{Id: "f1", ColdStart: coldstart.ToBoolPtr(), Version: "v2", TriggerType: "http"}
-		span           = SpanAggregationKey{SpanName: "spn", Resource: "postgresql"}
-		overflowSpan   = SpanAggregationKey{TargetName: "_other"}
+		span           = spanAggregationKey{SpanName: "spn", Resource: "postgresql"}
+		overflowSpan   = spanAggregationKey{TargetName: "_other"}
 		spanCount      = 1
-		svcTxn         = ServiceTransactionAggregationKey{TransactionType: "typ"}
-		overflowSvcTxn = ServiceTransactionAggregationKey{TransactionType: "_other"}
-		txn            = TransactionAggregationKey{TransactionName: "txn", TransactionType: "typ"}
-		txnFaas        = TransactionAggregationKey{TransactionName: "txn", TransactionType: "typ",
+		svcTxn         = serviceTransactionAggregationKey{TransactionType: "typ"}
+		overflowSvcTxn = serviceTransactionAggregationKey{TransactionType: "_other"}
+		txn            = transactionAggregationKey{TransactionName: "txn", TransactionType: "typ"}
+		txnFaas        = transactionAggregationKey{TransactionName: "txn", TransactionType: "typ",
 			FAASID: faas.Id, FAASColdstart: coldstart, FAASVersion: faas.Version, FAASTriggerType: faas.TriggerType}
-		overflowTxn = TransactionAggregationKey{TransactionName: "_other"}
+		overflowTxn = transactionAggregationKey{TransactionName: "_other"}
 		txnCount    = 100
 	)
 	for _, tc := range []struct {
@@ -349,8 +349,8 @@ func TestCombinedMetricsToBatch(t *testing.T) {
 				// Add global service overflow
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc_overflow"}).
-					AddServiceInstanceMetricsOverflow(ServiceInstanceAggregationKey{})
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc_overflow"}).
+					AddServiceInstanceMetricsOverflow(serviceInstanceAggregationKey{})
 				return tcm.GetProto()
 			},
 			expectedEvents: []*modelpb.APMEvent{
@@ -371,14 +371,14 @@ func TestCombinedMetricsToBatch(t *testing.T) {
 			combinedMetrics: func() *aggregationpb.CombinedMetrics {
 				tcm := NewTestCombinedMetrics()
 				tcm.
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{})
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{})
 				tcm.
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetricsOverflow(ServiceInstanceAggregationKey{GlobalLabelsStr: getTestGlobalLabelsStr(t, "1")})
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetricsOverflow(serviceInstanceAggregationKey{GlobalLabelsStr: getTestGlobalLabelsStr(t, "1")})
 				tcm.
-					AddServiceMetricsOverflow(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
-					AddServiceInstanceMetricsOverflow(ServiceInstanceAggregationKey{GlobalLabelsStr: getTestGlobalLabelsStr(t, "2")})
+					AddServiceMetricsOverflow(serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+					AddServiceInstanceMetricsOverflow(serviceInstanceAggregationKey{GlobalLabelsStr: getTestGlobalLabelsStr(t, "2")})
 				return tcm.GetProto()
 			},
 			expectedEvents: []*modelpb.APMEvent{
@@ -424,21 +424,21 @@ func BenchmarkCombinedMetricsToBatch(b *testing.B) {
 	pt := ts.Truncate(ai)
 	cardinality := 10
 	tcm := NewTestCombinedMetrics().
-		AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "bench"}).
-		AddServiceInstanceMetrics(ServiceInstanceAggregationKey{})
+		AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "bench"}).
+		AddServiceInstanceMetrics(serviceInstanceAggregationKey{})
 	for i := 0; i < cardinality; i++ {
 		txnName := fmt.Sprintf("txn%d", i)
 		txnType := fmt.Sprintf("typ%d", i)
 		spanName := fmt.Sprintf("spn%d", i)
 		tcm.
-			AddTransaction(TransactionAggregationKey{
+			AddTransaction(transactionAggregationKey{
 				TransactionName: txnName,
 				TransactionType: txnType,
 			}, WithTransactionCount(200)).
-			AddServiceTransaction(ServiceTransactionAggregationKey{
+			AddServiceTransaction(serviceTransactionAggregationKey{
 				TransactionType: txnType,
 			}, WithTransactionCount(200)).
-			AddSpan(SpanAggregationKey{
+			AddSpan(spanAggregationKey{
 				SpanName: spanName,
 			})
 	}
@@ -517,7 +517,7 @@ func createTestTransactionMetric(
 	ts time.Time,
 	ivl time.Duration,
 	svcName string,
-	txn TransactionAggregationKey,
+	txn transactionAggregationKey,
 	faas *modelpb.Faas,
 	count, overflowCount int,
 ) *modelpb.APMEvent {
@@ -577,7 +577,7 @@ func createTestServiceTransactionMetric(
 	ts time.Time,
 	ivl time.Duration,
 	svcName string,
-	svcTxn ServiceTransactionAggregationKey,
+	svcTxn serviceTransactionAggregationKey,
 	count, overflowCount int,
 ) *modelpb.APMEvent {
 	histRep := hdrhistogram.New()
@@ -628,7 +628,7 @@ func createTestSpanMetric(
 	ts time.Time,
 	ivl time.Duration,
 	svcName string,
-	span SpanAggregationKey,
+	span spanAggregationKey,
 	count, overflowCount int,
 ) *modelpb.APMEvent {
 	var metricsetSamples []*modelpb.MetricsetSample

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -63,6 +63,9 @@ func (m *combinedMetricsMerger) merge(from *aggregationpb.CombinedMetrics) {
 	if len(from.ServiceMetrics) == 0 {
 		return
 	}
+	if m.metrics.Services == nil {
+		m.metrics.Services = make(map[ServiceAggregationKey]ServiceMetrics)
+	}
 
 	// Calculate the current capacity of the transaction, service transaction,
 	// and span groups in the _to_ combined metrics.

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -38,7 +38,9 @@ func (m *combinedMetricsMerger) MergeOlder(value []byte) error {
 }
 
 func (m *combinedMetricsMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
-	data, err := m.metrics.MarshalBinary()
+	pb := m.metrics.ToProto()
+	defer pb.ReturnToVTPool()
+	data, err := pb.MarshalVT()
 	return data, nil, err
 }
 

--- a/aggregators/merger_test.go
+++ b/aggregators/merger_test.go
@@ -23,9 +23,9 @@ func TestMerge(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		limits   Limits
-		to       func() CombinedMetrics
+		to       func() combinedMetrics
 		from     func() *aggregationpb.CombinedMetrics
-		expected func() CombinedMetrics
+		expected func() combinedMetrics
 	}{
 		{
 			name: "no_overflow_with_count_values",
@@ -39,42 +39,42 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           2,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(10)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(5)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(5)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(5)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(5)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(4)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(2)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(2)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(2)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(2)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(14)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
 					Get()
 			},
@@ -91,42 +91,42 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           2,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1000)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(500)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(500)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(500)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(500)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(4)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(2)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(2)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(2)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(2)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1004)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(502)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(502)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(502)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(502)).
 					Get()
 			},
@@ -143,42 +143,42 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           2,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(4)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(2)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(2)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(2)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(2)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1000)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(500)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(500)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(500)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(500)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1004)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(502)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(502)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(502)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(502)).
 					Get()
 			},
@@ -195,42 +195,42 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           2,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1400)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(700)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(700)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(700)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(700)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1000)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(500)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(500)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(500)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(500)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(2400)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(1200)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(1200)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(1200)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(1200)).
 					Get()
 			},
@@ -247,51 +247,51 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(14)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(10)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type2"},
+						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
+						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(5)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(24)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
 					// no merge as span, transaction, and service transaction will overflow
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
 					// all span, transaction, and service transaction from _from_ will overflow
-					AddSpanOverflow(SpanAggregationKey{SpanName: ""}, WithSpanCount(5)).
+					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(5)).
 					AddServiceTransactionOverflow(
-						ServiceTransactionAggregationKey{TransactionType: "type2"},
+						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).
 					AddTransactionOverflow(
-						TransactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
+						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(5)).
 					Get()
 			},
@@ -308,57 +308,57 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(34)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
-					AddSpanOverflow(SpanAggregationKey{SpanName: ""}, WithSpanCount(10)).
+					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(10)).
 					AddServiceTransactionOverflow(
-						ServiceTransactionAggregationKey{TransactionType: "type2"},
+						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(10)).
 					AddTransactionOverflow(
-						TransactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
+						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(10)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(10)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type2"},
+						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
+						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(5)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(44)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
-					AddSpanOverflow(SpanAggregationKey{SpanName: ""}, WithSpanCount(15)).
+					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(15)).
 					AddServiceTransactionOverflow(
-						ServiceTransactionAggregationKey{TransactionType: "type2"},
+						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(15),
 					).
 					AddTransactionOverflow(
-						TransactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
+						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(15),
 					).
 					Get()
@@ -376,62 +376,62 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(14)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(26)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type2"},
+						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
+						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(5)).
-					AddSpanOverflow(SpanAggregationKey{SpanName: ""}, WithSpanCount(8)).
+					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(8)).
 					AddServiceTransactionOverflow(
-						ServiceTransactionAggregationKey{TransactionType: "type3"},
+						serviceTransactionAggregationKey{TransactionType: "type3"},
 						WithTransactionCount(8)).
 					AddTransactionOverflow(
-						TransactionAggregationKey{TransactionName: "txn3", TransactionType: "type3"},
+						transactionAggregationKey{TransactionName: "txn3", TransactionType: "type3"},
 						WithTransactionCount(8)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(40)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
-					AddSpanOverflow(SpanAggregationKey{SpanName: ""}, WithSpanCount(13)).
+					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(13)).
 					AddServiceTransactionOverflow(
-						ServiceTransactionAggregationKey{TransactionType: "type2"},
+						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).
 					AddTransactionOverflow(
-						TransactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
+						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(5)).
 					AddServiceTransactionOverflow(
-						ServiceTransactionAggregationKey{TransactionType: "type3"},
+						serviceTransactionAggregationKey{TransactionType: "type3"},
 						WithTransactionCount(8)).
 					AddTransactionOverflow(
-						TransactionAggregationKey{TransactionName: "txn3", TransactionType: "type3"},
+						transactionAggregationKey{TransactionName: "txn3", TransactionType: "type3"},
 						WithTransactionCount(8)).
 					Get()
 			},
@@ -448,17 +448,17 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(14)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(7)).
@@ -467,49 +467,49 @@ func TestMerge(t *testing.T) {
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(10)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(5)).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(5)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(5)).
 					AddTransaction(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(5)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				tcm := NewTestCombinedMetrics(WithEventsTotal(24))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(7))
 				// svc2 overflows
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
-					AddServiceInstanceMetricsOverflow(ServiceInstanceAggregationKey{}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+					AddServiceInstanceMetricsOverflow(serviceInstanceAggregationKey{}).
 					AddTransactionOverflow(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(5)).
 					AddServiceTransactionOverflow(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(5)).
 					AddSpanOverflow(
-						SpanAggregationKey{SpanName: "span1"}, WithSpanCount(5))
+						spanAggregationKey{SpanName: "span1"}, WithSpanCount(5))
 				return tcm.Get()
 			},
 		},
@@ -525,30 +525,30 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(111)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(222)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				tcm := NewTestCombinedMetrics(WithEventsTotal(333))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{})
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{})
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
-					AddServiceInstanceMetricsOverflow(ServiceInstanceAggregationKey{})
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+					AddServiceInstanceMetricsOverflow(serviceInstanceAggregationKey{})
 				return tcm.Get()
 			},
 		},
@@ -564,49 +564,49 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(14)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(10)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type2"},
+						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
+						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(5)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(24)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-					AddSpan(SpanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+					AddSpan(spanAggregationKey{SpanName: "span1"}, WithSpanCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
-					AddSpanOverflow(SpanAggregationKey{SpanName: ""}, WithSpanCount(5)).
+					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(5)).
 					AddServiceTransactionOverflow(
-						ServiceTransactionAggregationKey{TransactionType: "type2"},
+						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).
 					AddTransactionOverflow(
-						TransactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
+						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(5)).
 					Get()
 			},
@@ -623,23 +623,23 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    2,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{GlobalLabelsStr: "1"}).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{GlobalLabelsStr: "1"}).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(2)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{GlobalLabelsStr: "2"}).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{GlobalLabelsStr: "2"}).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				tcm := NewTestCombinedMetrics(WithEventsTotal(3))
-				sm := tcm.AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"})
-				sm.AddServiceInstanceMetrics(ServiceInstanceAggregationKey{GlobalLabelsStr: "1"})
-				sm.AddServiceInstanceMetrics(ServiceInstanceAggregationKey{GlobalLabelsStr: "2"})
+				sm := tcm.AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"})
+				sm.AddServiceInstanceMetrics(serviceInstanceAggregationKey{GlobalLabelsStr: "1"})
+				sm.AddServiceInstanceMetrics(serviceInstanceAggregationKey{GlobalLabelsStr: "2"})
 				return tcm.Get()
 			},
 		},
@@ -655,34 +655,34 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "1"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "1"}).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(2)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"}).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				tcm := NewTestCombinedMetrics(WithEventsTotal(3))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "1"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "1"})
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"})
 				return tcm.Get()
 			},
 		},
@@ -698,34 +698,34 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "1"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "1"}).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(2)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"}).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				tcm := NewTestCombinedMetrics(WithEventsTotal(3))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "1"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "1"})
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"})
 				return tcm.Get()
 			},
 		},
@@ -741,41 +741,41 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{GlobalLabelsStr: "1"}).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{GlobalLabelsStr: "1"}).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(1)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(2)).
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{GlobalLabelsStr: "2"}).
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{GlobalLabelsStr: "2"}).
 					AddTransaction(
-						TransactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
+						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(2)).
 					GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				tcm := NewTestCombinedMetrics(WithEventsTotal(3))
 				tsm := tcm.
-					AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"})
+					AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"})
 				tsm.
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "1"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "1"}).
 					AddTransaction(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(1))
 				tsm.
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"}).
 					AddTransactionOverflow(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(2))
@@ -794,96 +794,96 @@ func TestMerge(t *testing.T) {
 				MaxServices:                           1,
 				MaxServiceInstanceGroupsPerService:    1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				tcm := NewTestCombinedMetrics(WithEventsTotal(1))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "1"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "1"}).
 					AddTransaction(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(1))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"})
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc3"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc3"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "3"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "3"})
 				return tcm.Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				tcm := NewTestCombinedMetrics(WithEventsTotal(2))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"}).
 					AddTransaction(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(2))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "3"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "3"})
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc3"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc3"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "3"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "3"})
 				return tcm.GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				tcm := NewTestCombinedMetrics(WithEventsTotal(3))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetrics(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "1"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "1"}).
 					AddTransaction(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(1))
 				tcm.
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"})
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"}).
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"}).
 					AddTransactionOverflow(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(2))
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "2"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "2"})
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "3"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "3"})
 				tcm.
 					AddServiceMetricsOverflow(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc3"}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc3"}).
 					AddServiceInstanceMetricsOverflow(
-						ServiceInstanceAggregationKey{GlobalLabelsStr: "3"})
+						serviceInstanceAggregationKey{GlobalLabelsStr: "3"})
 				return tcm.Get()
 			},
 		},
@@ -898,36 +898,36 @@ func TestMerge(t *testing.T) {
 				MaxServiceTransactionGroupsPerService: 1,
 				MaxServices:                           1,
 			},
-			to: func() CombinedMetrics {
+			to: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(7)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
 					AddTransaction(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					Get()
 			},
 			from: func() *aggregationpb.CombinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(1)).GetProto()
 			},
-			expected: func() CombinedMetrics {
+			expected: func() combinedMetrics {
 				return NewTestCombinedMetrics(WithEventsTotal(8)).
 					AddServiceMetrics(
-						ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-					AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
+						serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+					AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
 					AddTransaction(
-						TransactionAggregationKey{
+						transactionAggregationKey{
 							TransactionName: "txn1",
 							TransactionType: "type1",
 						}, WithTransactionCount(7)).
 					AddServiceTransaction(
-						ServiceTransactionAggregationKey{TransactionType: "type1"},
+						serviceTransactionAggregationKey{TransactionType: "type1"},
 						WithTransactionCount(7)).
 					Get()
 			},
@@ -960,30 +960,30 @@ func TestCardinalityEstimationOnSubKeyCollision(t *testing.T) {
 	}
 	ts := time.Time{}
 	to := NewTestCombinedMetrics(WithEventsTotal(0)).
-		AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
-		AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
+		AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc1"}).
+		AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
 		Get()
 	from1 := NewTestCombinedMetrics(WithEventsTotal(10)).
-		AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
-		AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-		AddSpan(SpanAggregationKey{}, WithSpanCount(5)).
-		AddTransaction(TransactionAggregationKey{
+		AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc2"}).
+		AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+		AddSpan(spanAggregationKey{}, WithSpanCount(5)).
+		AddTransaction(transactionAggregationKey{
 			TransactionName: "txn1",
 			TransactionType: "type1",
 		}, WithTransactionCount(5)).
-		AddServiceTransaction(ServiceTransactionAggregationKey{
+		AddServiceTransaction(serviceTransactionAggregationKey{
 			TransactionType: "type1",
 		}, WithTransactionCount(5)).
 		GetProto()
 	from2 := NewTestCombinedMetrics(WithEventsTotal(10)).
-		AddServiceMetrics(ServiceAggregationKey{Timestamp: ts, ServiceName: "svc3"}).
-		AddServiceInstanceMetrics(ServiceInstanceAggregationKey{}).
-		AddSpan(SpanAggregationKey{}, WithSpanCount(5)).
-		AddTransaction(TransactionAggregationKey{
+		AddServiceMetrics(serviceAggregationKey{Timestamp: ts, ServiceName: "svc3"}).
+		AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+		AddSpan(spanAggregationKey{}, WithSpanCount(5)).
+		AddTransaction(transactionAggregationKey{
 			TransactionName: "txn1",
 			TransactionType: "type1",
 		}, WithTransactionCount(5)).
-		AddServiceTransaction(ServiceTransactionAggregationKey{
+		AddServiceTransaction(serviceTransactionAggregationKey{
 			TransactionType: "type1",
 		}, WithTransactionCount(5)).
 		GetProto()
@@ -1009,11 +1009,11 @@ func TestMergeHistogram(t *testing.T) {
 		hist2.RecordValues(v2, c2)
 	}
 
-	histproto1, histproto2 := HistogramToProto(hist1), HistogramToProto(hist2)
+	histproto1, histproto2 := histogramToProto(hist1), histogramToProto(hist2)
 	hist1.Merge(hist2)
 	mergeHistogram(histproto1, histproto2)
 	histActual := hdrhistogram.New()
-	HistogramFromProto(histActual, histproto1)
+	histogramFromProto(histActual, histproto1)
 
 	assert.Empty(t, cmp.Diff(
 		hist1,


### PR DESCRIPTION
Removes `FromProto` methods for all `*Metrics` struct.
Hides all non-proto structs as private structs other than `CombinedMetricsKey` and `GlobalLabels`

Follow up of #40 