### PR TITLE
Pool events for final processing of combined metrics

### DIFF
--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -445,9 +445,12 @@ func BenchmarkCombinedMetricsToBatch(b *testing.B) {
 	cm := tcm.GetProto()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := CombinedMetricsToBatch(cm, pt, ai)
+		batch, err := CombinedMetricsToBatch(cm, pt, ai)
 		if err != nil {
 			b.Fatal(err)
+		}
+		for _, e := range *batch {
+			e.ReturnToVTPool()
 		}
 	}
 }

--- a/aggregators/internal/hdrhistogram/hdrhistogram.go
+++ b/aggregators/internal/hdrhistogram/hdrhistogram.go
@@ -122,6 +122,8 @@ func (h *HistogramRepresentation) Buckets() (int64, []int64, []float64) {
 	var totalCount int64
 	var bucketsSeen int
 	iter := h.iterator()
+	// TODO @lahsivjar: Assuming sparse representation, we might be better off
+	// by sorting CountsRep rather than what we do now to avoid sorting.
 	for idx := 0; iter.next(); idx++ {
 		if bucketsSeen == h.CountsRep.Len() {
 			break

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/axiomhq/hyperloglog v0.0.0-20230201085229-3ddf4bad03dc
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cockroachdb/pebble v0.0.0-20230627193317-c807f60529a3
-	github.com/elastic/apm-data v0.1.1-0.20230718152028-9c38d2361527
+	github.com/elastic/apm-data v0.1.1-0.20230728063148-1076ea8b4db0
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
 	go.elastic.co/apm/module/apmotel/v2 v2.4.3

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsY
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
-github.com/elastic/apm-data v0.1.1-0.20230718152028-9c38d2361527 h1:ASiUA/r0Wwnhn3HXvNuLzn23ljsKJeQRZsDdODlxMco=
-github.com/elastic/apm-data v0.1.1-0.20230718152028-9c38d2361527/go.mod h1:lMTMoCWNadiDJih/tLechuMTtumEeedtKJlBOYAv030=
 github.com/elastic/apm-data v0.1.1-0.20230728063148-1076ea8b4db0 h1:dJEhfgmABnNyC//PM/CDCEEMg5l6I+KjHGDR6o1WMx4=
 github.com/elastic/apm-data v0.1.1-0.20230728063148-1076ea8b4db0/go.mod h1:lMTMoCWNadiDJih/tLechuMTtumEeedtKJlBOYAv030=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/elastic/apm-data v0.1.1-0.20230718152028-9c38d2361527 h1:ASiUA/r0Wwnhn3HXvNuLzn23ljsKJeQRZsDdODlxMco=
 github.com/elastic/apm-data v0.1.1-0.20230718152028-9c38d2361527/go.mod h1:lMTMoCWNadiDJih/tLechuMTtumEeedtKJlBOYAv030=
+github.com/elastic/apm-data v0.1.1-0.20230728063148-1076ea8b4db0 h1:dJEhfgmABnNyC//PM/CDCEEMg5l6I+KjHGDR6o1WMx4=
+github.com/elastic/apm-data v0.1.1-0.20230728063148-1076ea8b4db0/go.mod h1:lMTMoCWNadiDJih/tLechuMTtumEeedtKJlBOYAv030=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=
 github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=


### PR DESCRIPTION
Dependent on https://github.com/elastic/apm-data/pull/128

Benchmarking:

```
name                       old time/op    new time/op    delta
CombinedMetricsToBatch-10     202µs ± 0%     200µs ± 1%   -0.86%  (p=0.000 n=10+10)

name                       old alloc/op   new alloc/op   delta
CombinedMetricsToBatch-10    38.6kB ± 0%     4.2kB ± 0%  -89.15%  (p=0.000 n=8+9)

name                       old allocs/op  new allocs/op  delta
CombinedMetricsToBatch-10       308 ± 0%        95 ± 0%  -69.16%  (p=0.000 n=10+10)
```

Small gain in terms of `time/op`. For `time/op` it seems a lot of time is spent on `HDRHistogramRepresentation#Buckets`. I think it can be optimized for sparse representations, I have added a TODO.