### PR TITLE
Reduce fragmentation in EventToCombinedMetrics

### DIFF
--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -438,9 +438,16 @@ func histogramToProto(h *hdrhistogram.HistogramRepresentation) *aggregationpb.HD
 		return nil
 	}
 	pb := aggregationpb.HDRHistogramFromVTPool()
+	setHistogramProto(h, pb)
+	return pb
+}
+
+func setHistogramProto(h *hdrhistogram.HistogramRepresentation, pb *aggregationpb.HDRHistogram) {
 	pb.LowestTrackableValue = h.LowestTrackableValue
 	pb.HighestTrackableValue = h.HighestTrackableValue
 	pb.SignificantFigures = h.SignificantFigures
+	pb.Buckets = pb.Buckets[:0]
+	pb.Counts = pb.Counts[:0]
 	countsLen := h.CountsRep.Len()
 	if countsLen > cap(pb.Buckets) {
 		pb.Buckets = make([]int32, 0, countsLen)
@@ -452,7 +459,6 @@ func histogramToProto(h *hdrhistogram.HistogramRepresentation) *aggregationpb.HD
 		pb.Buckets = append(pb.Buckets, bucket)
 		pb.Counts = append(pb.Counts, value)
 	})
-	return pb
 }
 
 func hllBytes(estimator *hyperloglog.Sketch) []byte {

--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -174,7 +174,7 @@ func (p *partitionedMetricsBuilder) addDroppedSpanStatsMetrics(dss *modelpb.Drop
 
 	mb := p.get(p.hasher.Chain(&key))
 	i := len(mb.keyedSpanMetricsSlice)
-	if i == 128 { //len(mb.keyedSpanMetrics) {
+	if i == len(mb.keyedSpanMetricsArray) {
 		// No more capacity. The spec says that when 128 dropped span
 		// stats entries are reached, then any remaining entries will
 		// be silently discarded.

--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -87,6 +87,8 @@ func getPartitionedMetricsBuilder(
 	return p
 }
 
+// release releases all partitioned builders back to their pools.
+// Objects will be reset as needed if/when the builder is reacquired.
 func (p *partitionedMetricsBuilder) release() {
 	for i, mb := range p.builders {
 		mb.release()
@@ -293,6 +295,8 @@ func getEventMetricsBuilder(partition uint16) *eventMetricsBuilder {
 	return mb
 }
 
+// release releases the builder back to the pool.
+// Objects will be reset as needed if/when the builder is reacquired.
 func (mb *eventMetricsBuilder) release() {
 	eventMetricsBuilderPool.Put(mb)
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.39.0
 	go.opentelemetry.io/otel/trace v1.16.0
 	go.uber.org/zap v1.24.0
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/sync v0.3.0
 	google.golang.org/protobuf v1.31.0
 )
@@ -56,6 +55,7 @@ require (
 	go.elastic.co/fastjson v1.3.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.0 // indirect


### PR DESCRIPTION
Create pooled "metrics builder" objects, which contain enough space to produce metrics for a single event, and use interior pointers within the object to reduce allocations and the need for allocating/freeing/pooling many small objects.

```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics     
                            │ /tmp/main.txt │             /tmp/pr.txt             │
                            │    sec/op     │    sec/op     vs base               │
AggregateCombinedMetrics-16    2.904µ ±  8%   3.010µ ± 14%        ~ (p=0.485 n=6)
AggregateBatchSerial-16        9.913µ ±  7%   9.293µ ± 10%        ~ (p=0.065 n=6)
AggregateBatchParallel-16     12.715µ ± 13%   9.864µ ±  3%  -22.42% (p=0.002 n=6)
CombinedMetricsEncoding-16     1.422µ ±  4%   1.401µ ±  7%        ~ (p=1.000 n=6)
CombinedMetricsToBatch-16      332.0µ ±  2%   340.8µ ±  2%        ~ (p=0.065 n=6)
EventToCombinedMetrics-16     1039.0n ±  2%   431.9n ±  0%  -58.43% (p=0.002 n=6)
geomean                        7.511µ         6.201µ        -17.43%

                            │  /tmp/main.txt  │              /tmp/pr.txt              │
                            │      B/op       │     B/op       vs base                │
AggregateCombinedMetrics-16   1.486Ki ±  2%     1.466Ki ±  2%       ~ (p=0.331 n=6)
AggregateBatchSerial-16       2.988Ki ±  5%     2.994Ki ±  6%       ~ (p=0.667 n=6)
AggregateBatchParallel-16     3.000Ki ±  6%     2.826Ki ± 10%       ~ (p=0.180 n=6)
CombinedMetricsEncoding-16      928.0 ± 48%       923.5 ± 45%       ~ (p=0.669 n=6)
CombinedMetricsToBatch-16     4.015Ki ±  3%     4.007Ki ±  3%       ~ (p=0.485 n=6)
EventToCombinedMetrics-16       0.000 ±  0%       0.000 ±  0%       ~ (p=1.000 n=6) ¹
geomean                                     ²                  -1.29%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                            │ /tmp/main.txt │             /tmp/pr.txt             │
                            │   allocs/op   │  allocs/op   vs base                │
AggregateCombinedMetrics-16   24.00 ±  4%     23.00 ±  4%       ~ (p=0.567 n=6)
AggregateBatchSerial-16       44.00 ±  7%     44.50 ± 10%       ~ (p=0.645 n=6)
AggregateBatchParallel-16     44.50 ± 12%     40.50 ±  9%       ~ (p=0.162 n=6)
CombinedMetricsEncoding-16    0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=6) ¹
CombinedMetricsToBatch-16     95.00 ±  0%     95.00 ±  0%       ~ (p=1.000 n=6) ¹
EventToCombinedMetrics-16     0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=6) ¹
geomean                                   ²                -2.07%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```