### PR TITLE
perf: Merge histograms as sorted slices instead of using temp map

### DIFF
--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -452,6 +452,7 @@ func histogramToProto(h *hdrhistogram.HistogramRepresentation) *aggregationpb.HD
 		pb.Buckets = append(pb.Buckets, bucket)
 		pb.Counts = append(pb.Counts, value)
 	})
+	sort.Sort(hdrhistogram.SortBy[int32, int64]{By: pb.Buckets, Other: pb.Counts})
 	return pb
 }
 

--- a/aggregators/internal/hdrhistogram/sort.go
+++ b/aggregators/internal/hdrhistogram/sort.go
@@ -1,0 +1,23 @@
+package hdrhistogram
+
+import "golang.org/x/exp/constraints"
+
+// SortBy sorts 2 slices together. SortBy.By will be sorted and corresponding
+// swaps will happen in SortBy.Other.
+type SortBy[T constraints.Ordered, T2 any] struct {
+	By    []T
+	Other []T2
+}
+
+func (s SortBy[T, T2]) Len() int {
+	return len(s.By)
+}
+
+func (s SortBy[T, T2]) Swap(i, j int) {
+	s.By[i], s.By[j] = s.By[j], s.By[i]
+	s.Other[i], s.Other[j] = s.Other[j], s.Other[i]
+}
+
+func (s SortBy[T, T2]) Less(i, j int) bool {
+	return s.By[i] < s.By[j]
+}

--- a/aggregators/internal/hdrhistogram/sort.go
+++ b/aggregators/internal/hdrhistogram/sort.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package hdrhistogram
 
 import "golang.org/x/exp/constraints"

--- a/aggregators/internal/hdrhistogram/sort_test.go
+++ b/aggregators/internal/hdrhistogram/sort_test.go
@@ -1,0 +1,15 @@
+package hdrhistogram
+
+import (
+	"fmt"
+	"sort"
+)
+
+func Example() {
+	x := []int{3, 2, 1}
+	y := []string{"a", "b", "c"}
+	sort.Sort(SortBy[int, string]{x, y})
+	fmt.Println(x, y)
+	// Output:
+	// [1 2 3] [c b a]
+}

--- a/aggregators/internal/hdrhistogram/sort_test.go
+++ b/aggregators/internal/hdrhistogram/sort_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package hdrhistogram
 
 import (


### PR DESCRIPTION
Instead of using intermediate map for histogram merges, sort them before converting to proto and just merge sorted arrays. Significant performance gains even on top of #47.

mergeHistogram merges histogram `from` to `to` in 2 steps.
It mutates `from`.
1. Using binary search, it adds `from.Counts` to `to.Counts` if their corresponding bucket exists in to.Buckets.
2. If there are from.Buckets that do not exist in to.Buckets, allocate memory and merge the buckets and counts.

benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                               │ bench-out/agent-ndjson-bench-main-9fd99d │ bench-out/agent-ndjson-bench-hdrhistogram-sorted │
                               │                  sec/op                  │          sec/op            vs base               │
NDJSON/AgentNodeJS-16                                        40.75m ± 36%                17.62m ±  3%  -56.77% (p=0.002 n=6)
NDJSON/AgentNodeJS-512                                       43.48m ±  8%                18.30m ±  3%  -57.91% (p=0.002 n=6)
NDJSON/AgentPython-16                                        73.71m ±  3%                52.62m ±  2%  -28.60% (p=0.002 n=6)
NDJSON/AgentPython-512                                       73.31m ±  7%                54.63m ±  4%  -25.48% (p=0.002 n=6)
NDJSON/AgentRuby-16                                          58.71m ±  4%                27.34m ±  6%  -53.44% (p=0.002 n=6)
NDJSON/AgentRuby-512                                         59.58m ±  4%                28.93m ±  6%  -51.44% (p=0.002 n=6)
NDJSON/AgentGo-16                                            85.67m ±  8%                29.94m ±  3%  -65.06% (p=0.002 n=6)
NDJSON/AgentGo-512                                           86.51m ±  8%                35.96m ±  5%  -58.43% (p=0.002 n=6)
NDJSONParallel/AgentNodeJS-16                                39.57m ±  2%                17.69m ±  3%  -55.30% (p=0.002 n=6)
NDJSONParallel/AgentNodeJS-512                               39.76m ±  3%                18.42m ±  4%  -53.66% (p=0.002 n=6)
NDJSONParallel/AgentPython-16                                70.05m ±  3%                51.97m ±  4%  -25.81% (p=0.002 n=6)
NDJSONParallel/AgentPython-512                               71.21m ± 10%                53.14m ±  3%  -25.38% (p=0.002 n=6)
NDJSONParallel/AgentRuby-16                                  61.21m ± 34%                28.24m ± 92%  -53.87% (p=0.002 n=6)
NDJSONParallel/AgentRuby-512                                 59.92m ±  5%                30.26m ±  8%  -49.50% (p=0.002 n=6)
NDJSONParallel/AgentGo-16                                    88.93m ± 14%                30.35m ±  5%  -65.87% (p=0.002 n=6)
NDJSONParallel/AgentGo-512                                   89.42m ±  6%                36.53m ± 41%  -59.14% (p=0.002 n=6)
geomean                                                      62.68m                      30.85m        -50.78%

                               │ bench-out/agent-ndjson-bench-main-9fd99d │ bench-out/agent-ndjson-bench-hdrhistogram-sorted │
                               │                   B/op                   │           B/op             vs base               │
NDJSON/AgentNodeJS-16                                        7.419Mi ± 1%                7.133Mi ± 2%   -3.86% (p=0.002 n=6)
NDJSON/AgentNodeJS-512                                       7.539Mi ± 0%                7.244Mi ± 0%   -3.90% (p=0.002 n=6)
NDJSON/AgentPython-16                                        20.34Mi ± 2%                19.45Mi ± 1%   -4.42% (p=0.002 n=6)
NDJSON/AgentPython-512                                       20.63Mi ± 9%                19.67Mi ± 1%        ~ (p=0.065 n=6)
NDJSON/AgentRuby-16                                          11.48Mi ± 1%                10.99Mi ± 5%   -4.24% (p=0.002 n=6)
NDJSON/AgentRuby-512                                         11.51Mi ± 3%                11.02Mi ± 1%   -4.29% (p=0.002 n=6)
NDJSON/AgentGo-16                                            14.71Mi ± 3%                12.93Mi ± 1%  -12.05% (p=0.002 n=6)
NDJSON/AgentGo-512                                           14.54Mi ± 2%                12.89Mi ± 2%  -11.37% (p=0.002 n=6)
NDJSONParallel/AgentNodeJS-16                                7.410Mi ± 0%                7.134Mi ± 0%   -3.71% (p=0.002 n=6)
NDJSONParallel/AgentNodeJS-512                               7.532Mi ± 2%                7.243Mi ± 0%   -3.84% (p=0.002 n=6)
NDJSONParallel/AgentPython-16                                20.35Mi ± 1%                19.53Mi ± 1%   -4.02% (p=0.002 n=6)
NDJSONParallel/AgentPython-512                               20.46Mi ± 1%                19.69Mi ± 1%   -3.79% (p=0.002 n=6)
NDJSONParallel/AgentRuby-16                                  11.40Mi ± 3%                10.94Mi ± 3%   -4.06% (p=0.002 n=6)
NDJSONParallel/AgentRuby-512                                 11.49Mi ± 3%                10.90Mi ± 2%   -5.09% (p=0.002 n=6)
NDJSONParallel/AgentGo-16                                    14.79Mi ± 7%                13.02Mi ± 3%  -11.96% (p=0.002 n=6)
NDJSONParallel/AgentGo-512                                   14.53Mi ± 1%                12.87Mi ± 3%  -11.41% (p=0.002 n=6)
geomean                                                      12.66Mi                     11.88Mi        -6.10%

                               │ bench-out/agent-ndjson-bench-main-9fd99d │ bench-out/agent-ndjson-bench-hdrhistogram-sorted │
                               │                allocs/op                 │         allocs/op           vs base              │
NDJSON/AgentNodeJS-16                                        85.47k ±  0%                 83.08k ±  2%  -2.80% (p=0.002 n=6)
NDJSON/AgentNodeJS-512                                       84.92k ±  0%                 83.04k ±  0%  -2.21% (p=0.002 n=6)
NDJSON/AgentPython-16                                        219.5k ±  6%                 213.9k ±  2%       ~ (p=0.093 n=6)
NDJSON/AgentPython-512                                       218.2k ± 19%                 214.1k ±  1%       ~ (p=0.394 n=6)
NDJSON/AgentRuby-16                                          137.7k ±  3%                 135.1k ± 15%  -1.90% (p=0.015 n=6)
NDJSON/AgentRuby-512                                         134.0k ±  4%                 131.1k ±  1%       ~ (p=0.394 n=6)
NDJSON/AgentGo-16                                            167.6k ±  8%                 157.5k ±  4%  -6.04% (p=0.026 n=6)
NDJSON/AgentGo-512                                           156.2k ±  3%                 148.4k ±  5%  -5.00% (p=0.004 n=6)
NDJSONParallel/AgentNodeJS-16                                85.25k ±  0%                 83.05k ±  0%  -2.58% (p=0.002 n=6)
NDJSONParallel/AgentNodeJS-512                               85.17k ±  4%                 83.07k ±  0%       ~ (p=0.065 n=6)
NDJSONParallel/AgentPython-16                                219.2k ±  3%                 214.3k ±  2%       ~ (p=0.065 n=6)
NDJSONParallel/AgentPython-512                               216.1k ±  5%                 215.6k ±  2%       ~ (p=0.818 n=6)
NDJSONParallel/AgentRuby-16                                  135.3k ±  6%                 134.7k ± 10%       ~ (p=0.485 n=6)
NDJSONParallel/AgentRuby-512                                 131.3k ±  8%                 128.0k ±  6%       ~ (p=0.485 n=6)
NDJSONParallel/AgentGo-16                                    169.1k ± 14%                 160.4k ±  9%       ~ (p=0.065 n=6)
NDJSONParallel/AgentGo-512                                   156.1k ±  4%                 150.8k ±  5%       ~ (p=0.065 n=6)
geomean                                                      141.9k                       138.0k        -2.74%
```