### PR TITLE
WIP: Set max memtable size and set batch size accordingly

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	dbCommitThresholdBytes = 10 * 1024 * 1024 // commit every 10MB
+	memTableSize           = 16 << 20 // 16 MBs
+	dbCommitThresholdBytes = 7 << 20  // Keep it smaller than half of memtable size
 	aggregationIvlKey      = "aggregation_interval"
 )
 
@@ -85,6 +86,7 @@ func New(opts ...Option) (*Aggregator, error) {
 				return &merger, nil
 			},
 		},
+		MemTableSize: memTableSize,
 	}
 	writeOptions := pebble.Sync
 	if cfg.InMemory {

--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	memTableSize           = 16 << 20 // 16 MBs
-	dbCommitThresholdBytes = 7 << 20  // Keep it smaller than half of memtable size
+	dbCommitThresholdBytes = 6 << 20  // Keep it smaller than half of memtable size
 	aggregationIvlKey      = "aggregation_interval"
 )
 


### PR DESCRIPTION
Sets the memtable size to be 16MB (default is 4MB) and the max batch size to be 6MBs (so that the batch is not marked as a large batch). A large batch forces WAL rotation and is added as another readable layer in the LSM.

WIP: Benchmarks (There shouldn't be a lot of performance improvements, if any.)