### PR TITLE
Remove Partitioner interface

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -326,7 +326,7 @@ func (a *Aggregator) aggregateAPMEvent(
 		totalBytesIn += bytesIn
 		return err
 	}
-	err := EventToCombinedMetrics(e, cmk, a.cfg.Partitioner, aggregateFunc)
+	err := EventToCombinedMetrics(e, cmk, a.cfg.Partitions, aggregateFunc)
 	if err != nil {
 		return 0, fmt.Errorf("failed to aggregate combined metrics: %w", err)
 	}


### PR DESCRIPTION
Configure a number of partitions, and always just calculate the partition has `hash%partitions`. The existing API is more or less required to do this anyway, since it receives a hash.

I'm intending to move the `EventToCombinedMetrics` function and related code to a separate internal package, and this will simplify that.