### PR TITLE
vtprotobuf: Reuse backing array with referenced structs instead of pooling individual objects

### DIFF
--- a/aggregationpb/aggregation_vtproto.pb.go
+++ b/aggregationpb/aggregation_vtproto.pb.go
@@ -1756,9 +1756,8 @@ var vtprotoPool_CombinedMetrics = sync.Pool{
 }
 
 func (m *CombinedMetrics) ResetVT() {
-	for k, mm := range m.ServiceMetrics {
-		mm.ReturnToVTPool()
-		m.ServiceMetrics[k] = nil
+	for _, mm := range m.ServiceMetrics {
+		mm.ResetVT()
 	}
 	f0 := m.ServiceMetrics[:0]
 	m.OverflowServices.ReturnToVTPool()
@@ -1826,9 +1825,8 @@ var vtprotoPool_ServiceMetrics = sync.Pool{
 }
 
 func (m *ServiceMetrics) ResetVT() {
-	for k, mm := range m.ServiceInstanceMetrics {
-		mm.ReturnToVTPool()
-		m.ServiceInstanceMetrics[k] = nil
+	for _, mm := range m.ServiceInstanceMetrics {
+		mm.ResetVT()
 	}
 	f0 := m.ServiceInstanceMetrics[:0]
 	m.OverflowGroups.ReturnToVTPool()
@@ -1873,19 +1871,16 @@ var vtprotoPool_ServiceInstanceMetrics = sync.Pool{
 }
 
 func (m *ServiceInstanceMetrics) ResetVT() {
-	for k, mm := range m.TransactionMetrics {
-		mm.ReturnToVTPool()
-		m.TransactionMetrics[k] = nil
+	for _, mm := range m.TransactionMetrics {
+		mm.ResetVT()
 	}
 	f0 := m.TransactionMetrics[:0]
-	for k, mm := range m.ServiceTransactionMetrics {
-		mm.ReturnToVTPool()
-		m.ServiceTransactionMetrics[k] = nil
+	for _, mm := range m.ServiceTransactionMetrics {
+		mm.ResetVT()
 	}
 	f1 := m.ServiceTransactionMetrics[:0]
-	for k, mm := range m.SpanMetrics {
-		mm.ReturnToVTPool()
-		m.SpanMetrics[k] = nil
+	for _, mm := range m.SpanMetrics {
+		mm.ResetVT()
 	}
 	f2 := m.SpanMetrics[:0]
 	m.Reset()

--- a/aggregationpb/labels_vtproto.pb.go
+++ b/aggregationpb/labels_vtproto.pb.go
@@ -280,14 +280,12 @@ var vtprotoPool_GlobalLabels = sync.Pool{
 }
 
 func (m *GlobalLabels) ResetVT() {
-	for k, mm := range m.Labels {
-		mm.ReturnToVTPool()
-		m.Labels[k] = nil
+	for _, mm := range m.Labels {
+		mm.ResetVT()
 	}
 	f0 := m.Labels[:0]
-	for k, mm := range m.NumericLabels {
-		mm.ReturnToVTPool()
-		m.NumericLabels[k] = nil
+	for _, mm := range m.NumericLabels {
+		mm.ResetVT()
 	}
 	f1 := m.NumericLabels[:0]
 	m.Reset()

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -83,14 +83,15 @@ func (k *CombinedMetricsKey) SizeBinary() int {
 // ToProto converts CombinedMetrics to its protobuf representation.
 func (m *combinedMetrics) ToProto() *aggregationpb.CombinedMetrics {
 	pb := aggregationpb.CombinedMetricsFromVTPool()
-	pb.ServiceMetrics = slices.Grow(pb.ServiceMetrics, len(m.Services))
+	pb.ServiceMetrics = slices.Grow(pb.ServiceMetrics, len(m.Services))[:len(m.Services)]
+	var i int
 	for k, m := range m.Services {
-		pb.ServiceMetrics = pb.ServiceMetrics[:len(pb.ServiceMetrics)+1]
-		if pb.ServiceMetrics[len(pb.ServiceMetrics)-1] == nil {
-			pb.ServiceMetrics[len(pb.ServiceMetrics)-1] = &aggregationpb.KeyedServiceMetrics{}
+		if pb.ServiceMetrics[i] == nil {
+			pb.ServiceMetrics[i] = &aggregationpb.KeyedServiceMetrics{}
 		}
-		pb.ServiceMetrics[len(pb.ServiceMetrics)-1].Key = k.ToProto()
-		pb.ServiceMetrics[len(pb.ServiceMetrics)-1].Metrics = m.ToProto()
+		pb.ServiceMetrics[i].Key = k.ToProto()
+		pb.ServiceMetrics[i].Metrics = m.ToProto()
+		i++
 	}
 	if m.OverflowServiceInstancesEstimator != nil {
 		pb.OverflowServices = m.OverflowServices.ToProto()
@@ -124,14 +125,15 @@ func (k *serviceAggregationKey) FromProto(pb *aggregationpb.ServiceAggregationKe
 // ToProto converts ServiceMetrics to its protobuf representation.
 func (m *serviceMetrics) ToProto() *aggregationpb.ServiceMetrics {
 	pb := aggregationpb.ServiceMetricsFromVTPool()
-	pb.ServiceInstanceMetrics = slices.Grow(pb.ServiceInstanceMetrics, len(m.ServiceInstanceGroups))
+	pb.ServiceInstanceMetrics = slices.Grow(pb.ServiceInstanceMetrics, len(m.ServiceInstanceGroups))[:len(m.ServiceInstanceGroups)]
+	var i int
 	for k, m := range m.ServiceInstanceGroups {
-		pb.ServiceInstanceMetrics = pb.ServiceInstanceMetrics[:len(pb.ServiceInstanceMetrics)+1]
-		if pb.ServiceInstanceMetrics[len(pb.ServiceInstanceMetrics)-1] == nil {
-			pb.ServiceInstanceMetrics[len(pb.ServiceInstanceMetrics)-1] = &aggregationpb.KeyedServiceInstanceMetrics{}
+		if pb.ServiceInstanceMetrics[i] == nil {
+			pb.ServiceInstanceMetrics[i] = &aggregationpb.KeyedServiceInstanceMetrics{}
 		}
-		pb.ServiceInstanceMetrics[len(pb.ServiceInstanceMetrics)-1].Key = k.ToProto()
-		pb.ServiceInstanceMetrics[len(pb.ServiceInstanceMetrics)-1].Metrics = m.ToProto()
+		pb.ServiceInstanceMetrics[i].Key = k.ToProto()
+		pb.ServiceInstanceMetrics[i].Metrics = m.ToProto()
+		i++
 	}
 	pb.OverflowGroups = m.OverflowGroups.ToProto()
 	return pb
@@ -334,29 +336,31 @@ func (gl *GlobalLabels) ToProto() *aggregationpb.GlobalLabels {
 
 	// Keys must be sorted to ensure wire formats are deterministically generated and strings are directly comparable
 	// i.e. Protobuf formats are equal if and only if the structs are equal
-	pb.Labels = slices.Grow(pb.Labels, len(gl.Labels))
+	pb.Labels = slices.Grow(pb.Labels, len(gl.Labels))[:len(gl.Labels)]
+	var i int
 	for k, v := range gl.Labels {
-		pb.Labels = pb.Labels[:len(pb.Labels)+1]
-		if pb.Labels[len(pb.Labels)-1] == nil {
-			pb.Labels[len(pb.Labels)-1] = &aggregationpb.Label{}
+		if pb.Labels[i] == nil {
+			pb.Labels[i] = &aggregationpb.Label{}
 		}
-		pb.Labels[len(pb.Labels)-1].Key = k
-		pb.Labels[len(pb.Labels)-1].Value = v.Value
-		pb.Labels[len(pb.Labels)-1].Values = v.Values
+		pb.Labels[i].Key = k
+		pb.Labels[i].Value = v.Value
+		pb.Labels[i].Values = v.Values
+		i++
 	}
 	sort.Slice(pb.Labels, func(i, j int) bool {
 		return pb.Labels[i].Key < pb.Labels[j].Key
 	})
 
-	pb.NumericLabels = slices.Grow(pb.NumericLabels, len(gl.NumericLabels))
+	pb.NumericLabels = slices.Grow(pb.NumericLabels, len(gl.NumericLabels))[:len(gl.NumericLabels)]
+	i = 0
 	for k, v := range gl.NumericLabels {
-		pb.NumericLabels = pb.NumericLabels[:len(pb.NumericLabels)+1]
-		if pb.NumericLabels[len(pb.NumericLabels)-1] == nil {
-			pb.NumericLabels[len(pb.NumericLabels)-1] = &aggregationpb.NumericLabel{}
+		if pb.NumericLabels[i] == nil {
+			pb.NumericLabels[i] = &aggregationpb.NumericLabel{}
 		}
-		pb.NumericLabels[len(pb.NumericLabels)-1].Key = k
-		pb.NumericLabels[len(pb.NumericLabels)-1].Value = v.Value
-		pb.NumericLabels[len(pb.NumericLabels)-1].Values = v.Values
+		pb.NumericLabels[i].Key = k
+		pb.NumericLabels[i].Value = v.Value
+		pb.NumericLabels[i].Values = v.Values
+		i++
 	}
 	sort.Slice(pb.NumericLabels, func(i, j int) bool {
 		return pb.NumericLabels[i].Key < pb.NumericLabels[j].Key

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -216,7 +216,6 @@ func mergeTransactionGroups(
 			globalConstraint.add(1)
 
 			to[tk] = fromTxn.CloneVT()
-			//from[i] = nil
 			continue
 		}
 		mergeKeyedTransactionMetrics(toTxn, fromTxn)
@@ -251,7 +250,6 @@ func mergeServiceTransactionGroups(
 			globalConstraint.add(1)
 
 			to[stk] = fromSvcTxn.CloneVT()
-			//from[i] = nil
 			continue
 		}
 		mergeKeyedServiceTransactionMetrics(toSvcTxn, fromSvcTxn)
@@ -294,7 +292,6 @@ func mergeSpanGroups(
 				globalConstraint.add(1)
 
 				to[spk] = fromSpan.CloneVT()
-				//from[i] = nil
 				continue
 			}
 		}

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -215,8 +215,8 @@ func mergeTransactionGroups(
 			perSvcConstraint.add(1)
 			globalConstraint.add(1)
 
-			to[tk] = fromTxn
-			from[i] = nil
+			to[tk] = fromTxn.CloneVT()
+			//from[i] = nil
 			continue
 		}
 		mergeKeyedTransactionMetrics(toTxn, fromTxn)
@@ -250,8 +250,8 @@ func mergeServiceTransactionGroups(
 			perSvcConstraint.add(1)
 			globalConstraint.add(1)
 
-			to[stk] = fromSvcTxn
-			from[i] = nil
+			to[stk] = fromSvcTxn.CloneVT()
+			//from[i] = nil
 			continue
 		}
 		mergeKeyedServiceTransactionMetrics(toSvcTxn, fromSvcTxn)
@@ -293,8 +293,8 @@ func mergeSpanGroups(
 				perSvcConstraint.add(1)
 				globalConstraint.add(1)
 
-				to[spk] = fromSpan
-				from[i] = nil
+				to[spk] = fromSpan.CloneVT()
+				//from[i] = nil
 				continue
 			}
 		}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -17,4 +17,4 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
-replace github.com/planetscale/vtprotobuf => github.com/carsonip/vtprotobuf v0.0.0-20230711135402-2cf3150fde0e
+replace github.com/planetscale/vtprotobuf => github.com/grafana/vtprotobuf v0.0.0-20230722075033-e8044ca07485

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,13 +1,13 @@
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/carsonip/vtprotobuf v0.0.0-20230711135402-2cf3150fde0e h1:lcgWGj99s7E/NzQTsyKtFN+VkHPmYAA8U73Y9fBFZdU=
-github.com/carsonip/vtprotobuf v0.0.0-20230711135402-2cf3150fde0e/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0PbwYYpP5P5VhTks=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-licenser v0.4.1 h1:1xDURsc8pL5zYT9R29425J3vkHdt4RT5TNEMeRN48x4=
 github.com/elastic/go-licenser v0.4.1/go.mod h1:V56wHMpmdURfibNBggaSBfqgPxyT1Tldns1i87iTEvU=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/grafana/vtprotobuf v0.0.0-20230722075033-e8044ca07485 h1:gJYcsZJneV9DVvrcmmvGJLiuM/p+tcJ4cYu9oWvES2s=
+github.com/grafana/vtprotobuf v0.0.0-20230722075033-e8044ca07485/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0PbwYYpP5P5VhTks=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
Alternative to #37 , but using vtprotobuf fork that reuses backing array including referenced structs, which has an upstream PR. With this, we will no longer be pooling Keyed* individually. Either with this or #37, there will be significantly fewer garbage.

Closes #20

benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                       │ bench-out/vt-unmarshal-pooling-including-structs-2-before │ bench-out/vt-unmarshal-pooling-including-structs-2-after │
                                       │                          sec/op                           │              sec/op                vs base               │
AggregateCombinedMetrics-16                                                            2.001µ ± 1%                         1.926µ ± 1%   -3.75% (p=0.002 n=6)
AggregateBatchSerial-16                                                                5.227µ ± 1%                         4.489µ ± 5%  -14.11% (p=0.002 n=6)
AggregateBatchParallel-16                                                              5.524µ ± 9%                         5.008µ ± 3%   -9.33% (p=0.002 n=6)
CombinedMetricsEncoding-16                                                            1410.0n ± 3%                         878.5n ± 2%  -37.69% (p=0.002 n=6)
CombinedMetricsToBatch-16                                                              61.90µ ± 1%                         61.41µ ± 2%        ~ (p=0.132 n=6)
EventToCombinedMetrics-16                                                              420.7n ± 2%                         418.4n ± 3%        ~ (p=0.240 n=6)
NDJSONSerial/go-2.0.0.ndjson-16                                                        19.11m ± 3%                         16.84m ± 4%  -11.88% (p=0.002 n=6)
NDJSONSerial/nodejs-3.29.0.ndjson-16                                                  10.980m ± 4%                         9.488m ± 3%  -13.59% (p=0.002 n=6)
NDJSONSerial/python-6.7.2.ndjson-16                                                    27.13m ± 4%                         23.21m ± 3%  -14.45% (p=0.002 n=6)
NDJSONSerial/ruby-4.5.0.ndjson-16                                                      16.14m ± 1%                         13.95m ± 4%  -13.57% (p=0.002 n=6)
NDJSONParallel/go-2.0.0.ndjson-16                                                      19.17m ± 4%                         16.71m ± 7%  -12.85% (p=0.002 n=6)
NDJSONParallel/nodejs-3.29.0.ndjson-16                                                11.005m ± 3%                         9.518m ± 6%  -13.51% (p=0.002 n=6)
NDJSONParallel/python-6.7.2.ndjson-16                                                  27.26m ± 2%                         23.03m ± 3%  -15.54% (p=0.002 n=6)
NDJSONParallel/ruby-4.5.0.ndjson-16                                                    16.25m ± 3%                         13.98m ± 3%  -13.97% (p=0.002 n=6)
geomean                                                                                458.6µ                              399.0µ       -13.01%

                                       │ bench-out/vt-unmarshal-pooling-including-structs-2-before │ bench-out/vt-unmarshal-pooling-including-structs-2-after │
                                       │                           B/op                            │             B/op              vs base                    │
AggregateCombinedMetrics-16                                                        1.416Ki ±  0%                     1.104Ki ± 1%   -22.01% (p=0.002 n=6)
AggregateBatchSerial-16                                                            2.459Ki ±  2%                     1.373Ki ± 3%   -44.17% (p=0.002 n=6)
AggregateBatchParallel-16                                                          2.500Ki ±  3%                     1.370Ki ± 3%   -45.21% (p=0.002 n=6)
CombinedMetricsEncoding-16                                                           855.0 ± 44%                         0.0 ± 0%  -100.00% (p=0.002 n=6)
CombinedMetricsToBatch-16                                                          3.986Ki ±  3%                     3.982Ki ± 0%         ~ (p=0.502 n=6)
EventToCombinedMetrics-16                                                            0.000 ±  0%                       0.000 ± 0%         ~ (p=1.000 n=6) ¹
NDJSONSerial/go-2.0.0.ndjson-16                                                   11.591Mi ±  0%                     9.249Mi ± 1%   -20.21% (p=0.002 n=6)
NDJSONSerial/nodejs-3.29.0.ndjson-16                                               7.007Mi ±  0%                     5.589Mi ± 1%   -20.23% (p=0.002 n=6)
NDJSONSerial/python-6.7.2.ndjson-16                                                19.59Mi ±  1%                     15.32Mi ± 1%   -21.78% (p=0.002 n=6)
NDJSONSerial/ruby-4.5.0.ndjson-16                                                 10.418Mi ±  0%                     8.261Mi ± 0%   -20.71% (p=0.002 n=6)
NDJSONParallel/go-2.0.0.ndjson-16                                                 11.597Mi ±  0%                     9.233Mi ± 1%   -20.38% (p=0.002 n=6)
NDJSONParallel/nodejs-3.29.0.ndjson-16                                             7.011Mi ±  0%                     5.563Mi ± 1%   -20.66% (p=0.002 n=6)
NDJSONParallel/python-6.7.2.ndjson-16                                              19.63Mi ±  1%                     15.32Mi ± 1%   -21.94% (p=0.002 n=6)
NDJSONParallel/ruby-4.5.0.ndjson-16                                               10.424Mi ±  0%                     8.256Mi ± 0%   -20.80% (p=0.002 n=6)
geomean                                                                                          ²                                 ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                       │ bench-out/vt-unmarshal-pooling-including-structs-2-before │ bench-out/vt-unmarshal-pooling-including-structs-2-after │
                                       │                         allocs/op                         │            allocs/op             vs base                 │
AggregateCombinedMetrics-16                                                           21.00 ± 0%                          17.00 ± 0%  -19.05% (p=0.002 n=6)
AggregateBatchSerial-16                                                               26.00 ± 4%                          13.00 ± 8%  -50.00% (p=0.002 n=6)
AggregateBatchParallel-16                                                             26.50 ± 6%                          13.00 ± 8%  -50.94% (p=0.002 n=6)
CombinedMetricsEncoding-16                                                            0.000 ± 0%                          0.000 ± 0%        ~ (p=1.000 n=6) ¹
CombinedMetricsToBatch-16                                                             95.00 ± 0%                          95.00 ± 0%        ~ (p=1.000 n=6) ¹
EventToCombinedMetrics-16                                                             0.000 ± 0%                          0.000 ± 0%        ~ (p=1.000 n=6) ¹
NDJSONSerial/go-2.0.0.ndjson-16                                                      142.1k ± 0%                         114.1k ± 2%  -19.66% (p=0.002 n=6)
NDJSONSerial/nodejs-3.29.0.ndjson-16                                                 79.18k ± 1%                         63.79k ± 1%  -19.43% (p=0.002 n=6)
NDJSONSerial/python-6.7.2.ndjson-16                                                  215.4k ± 1%                         162.7k ± 1%  -24.49% (p=0.002 n=6)
NDJSONSerial/ruby-4.5.0.ndjson-16                                                   124.53k ± 0%                         98.87k ± 0%  -20.61% (p=0.002 n=6)
NDJSONParallel/go-2.0.0.ndjson-16                                                    142.0k ± 0%                         113.9k ± 1%  -19.81% (p=0.002 n=6)
NDJSONParallel/nodejs-3.29.0.ndjson-16                                               79.20k ± 0%                         63.17k ± 1%  -20.24% (p=0.002 n=6)
NDJSONParallel/python-6.7.2.ndjson-16                                                215.4k ± 2%                         163.2k ± 1%  -24.23% (p=0.002 n=6)
NDJSONParallel/ruby-4.5.0.ndjson-16                                                 124.54k ± 1%                         99.09k ± 0%  -20.43% (p=0.002 n=6)
geomean                                                                                          ²                                    -22.21%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

macro benchmark:
```
                           │ github/run82.txt │         github/run83-vt.txt         │
                           │    events/sec    │  events/sec   vs base               │
10000AggregationGroups-512       13.76k ± 35%   15.90k ± 32%        ~ (p=0.132 n=6)
1000Transactions-512             13.72k ± 33%   18.83k ± 28%        ~ (p=0.065 n=6)
AgentAll-512                     9.124k ± 19%   8.998k ± 50%        ~ (p=0.818 n=6)
AgentGo-512                      11.15k ± 22%   12.01k ± 53%        ~ (p=0.310 n=6)
AgentNodeJS-512                  5.777k ± 28%   6.611k ± 29%        ~ (p=0.093 n=6)
AgentPython-512                  6.825k ± 26%   7.422k ± 76%        ~ (p=0.180 n=6)
AgentRuby-512                    7.332k ± 44%   7.387k ± 67%        ~ (p=0.368 n=6)
geomean                          9.193k         10.23k        +11.28%
```