### PR TITLE
perf: Add mergeHistogram fast path

### DIFF
--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -384,6 +384,7 @@ func mergeSpanMetrics(to, from *aggregationpb.SpanMetrics) {
 // mergeHistogram merges two proto representation of HDRHistogram. The
 // merge assumes both histograms are created with same arguments and
 // their representations are sorted by bucket.
+// Caution: this function may mutate from.Count.
 func mergeHistogram(to, from *aggregationpb.HDRHistogram) {
 	if len(from.Buckets) == 0 {
 		return

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -417,7 +417,7 @@ func mergeHistogram(to, from *aggregationpb.HDRHistogram) {
 			} else {
 				extra++
 			}
-			// Invariance:
+			// Invariants:
 			// to.Buckets[toIdx] >= from.Buckets[fromIdx] (defined by sort.Find)
 			// from.Buckets[i-1] < from.Buckets[i] (buckets are strictly increasing)
 			// to.Buckets[i-1] < to.Buckets[i]  (buckets are strictly increasing)

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -5,11 +5,12 @@
 package aggregators
 
 import (
+	"io"
+	"sort"
+
 	"github.com/axiomhq/hyperloglog"
 	"github.com/cespare/xxhash/v2"
 	"golang.org/x/exp/slices"
-	"io"
-	"sort"
 
 	"github.com/elastic/apm-aggregation/aggregationpb"
 	"github.com/elastic/apm-aggregation/aggregators/internal/constraint"

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -385,7 +385,7 @@ func mergeSpanMetrics(to, from *aggregationpb.SpanMetrics) {
 // mergeHistogram merges two proto representation of HDRHistogram. The
 // merge assumes both histograms are created with same arguments and
 // their representations are sorted by bucket.
-// Caution: this function may mutate from.Count.
+// Caution: this function may mutate from.Counts.
 func mergeHistogram(to, from *aggregationpb.HDRHistogram) {
 	if len(from.Buckets) == 0 {
 		return

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -417,6 +417,15 @@ func mergeHistogram(to, from *aggregationpb.HDRHistogram) {
 			} else {
 				extra++
 			}
+			// Invariance:
+			// to.Buckets[toIdx] >= from.Buckets[fromIdx] (defined by sort.Find)
+			// from.Buckets[i-1] < from.Buckets[i] (buckets are strictly increasing)
+			// to.Buckets[i-1] < to.Buckets[i]  (buckets are strictly increasing)
+			//
+			// Therefore:
+			// from.Buckets[fromIdx-1] < to.Buckets[toIdx]
+			// In the next pass, we can safely search in to.Buckets[0:toIdx], i.e. calling sort.Find(toIdx, ...).
+			// Edge case: where from.Buckets[fromIdx-1] > to.Buckets[toIdx-1], sort.Find will return (toIdx, false).
 			searchToLen = toIdx
 		}
 		if extra == 0 {

--- a/aggregators/merger_test.go
+++ b/aggregators/merger_test.go
@@ -1147,31 +1147,31 @@ func TestMergeHistogram(t *testing.T) {
 		{
 			name: "from_between_to",
 			to: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 3000},
-				Counts:  []int64{1, 3},
+				Buckets: []int32{1000, 4000, 5000},
+				Counts:  []int64{1, 4, 5},
 			},
 			from: &aggregationpb.HDRHistogram{
-				Buckets: []int32{2000},
-				Counts:  []int64{2},
+				Buckets: []int32{2000, 3000},
+				Counts:  []int64{2, 3},
 			},
 			expected: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 2000, 3000},
-				Counts:  []int64{1, 2, 3},
+				Buckets: []int32{1000, 2000, 3000, 4000, 5000},
+				Counts:  []int64{1, 2, 3, 4, 5},
 			},
 		},
 		{
 			name: "to_between_from",
 			to: &aggregationpb.HDRHistogram{
-				Buckets: []int32{2000},
-				Counts:  []int64{2},
+				Buckets: []int32{2000, 3000},
+				Counts:  []int64{2, 3},
 			},
 			from: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 3000},
-				Counts:  []int64{1, 3},
+				Buckets: []int32{1000, 4000, 5000},
+				Counts:  []int64{1, 4, 5},
 			},
 			expected: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 2000, 3000},
-				Counts:  []int64{1, 2, 3},
+				Buckets: []int32{1000, 2000, 3000, 4000, 5000},
+				Counts:  []int64{1, 2, 3, 4, 5},
 			},
 		},
 		{


### PR DESCRIPTION
Add fast path for mergeHistogram since it is using the most time in CPU profiles. This optimizes for cases where `len(from.Bucket) << len(to.Bucket)` so that we will have O(m lg n) as opposed to the regular O(n + m), where m = len(from.Bucket) and n = len(to.Bucket). This idea is from #49 but not implemented in the merged #52.

benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                       │ bench-out/merge-histogram-fastpath-7-before │ bench-out/merge-histogram-fastpath-7-after │
                                       │                   sec/op                    │       sec/op         vs base               │
AggregateCombinedMetrics-16                                              1.893µ ± 6%           1.878µ ± 3%        ~ (p=0.310 n=6)
AggregateBatchSerial-16                                                  4.469µ ± 5%           4.407µ ± 4%        ~ (p=0.394 n=6)
AggregateBatchParallel-16                                                4.968µ ± 6%           4.957µ ± 2%        ~ (p=0.669 n=6)
CombinedMetricsEncoding-16                                               907.6n ± 5%           902.3n ± 3%        ~ (p=0.818 n=6)
CombinedMetricsToBatch-16                                                60.76µ ± 2%           62.81µ ± 2%   +3.38% (p=0.002 n=6)
EventToCombinedMetrics-16                                                398.3n ± 5%           384.2n ± 2%   -3.54% (p=0.002 n=6)
NDJSONSerial/go-2.0.0.ndjson-16                                          16.67m ± 2%           15.33m ± 5%   -8.00% (p=0.002 n=6)
NDJSONSerial/nodejs-3.29.0.ndjson-16                                     9.418m ± 4%           8.933m ± 3%   -5.15% (p=0.004 n=6)
NDJSONSerial/python-6.7.2.ndjson-16                                      23.54m ± 3%           23.39m ± 8%        ~ (p=0.093 n=6)
NDJSONSerial/ruby-4.5.0.ndjson-16                                        13.81m ± 2%           13.31m ± 5%   -3.62% (p=0.041 n=6)
NDJSONParallel/go-2.0.0.ndjson-16                                        16.87m ± 4%           15.02m ± 4%  -10.93% (p=0.002 n=6)
NDJSONParallel/nodejs-3.29.0.ndjson-16                                   9.521m ± 9%           8.890m ± 5%   -6.62% (p=0.002 n=6)
NDJSONParallel/python-6.7.2.ndjson-16                                    23.20m ± 2%           23.00m ± 1%        ~ (p=0.394 n=6)
NDJSONParallel/ruby-4.5.0.ndjson-16                                      14.12m ± 3%           13.28m ± 3%   -5.94% (p=0.002 n=6)
geomean                                                                  397.7µ                384.7µ        -3.28%

                                       │ bench-out/merge-histogram-fastpath-7-before │ bench-out/merge-histogram-fastpath-7-after │
                                       │                    B/op                     │        B/op         vs base                │
AggregateCombinedMetrics-16                                           1.103Ki ± 1%           1.104Ki ± 1%       ~ (p=0.859 n=6)
AggregateBatchSerial-16                                               1.368Ki ± 2%           1.362Ki ± 2%       ~ (p=0.180 n=6)
AggregateBatchParallel-16                                             1.353Ki ± 2%           1.372Ki ± 1%       ~ (p=0.234 n=6)
CombinedMetricsEncoding-16                                              0.000 ± 0%             0.000 ± 0%       ~ (p=1.000 n=6) ¹
CombinedMetricsToBatch-16                                             3.983Ki ± 0%           3.983Ki ± 0%       ~ (p=0.472 n=6)
EventToCombinedMetrics-16                                               0.000 ± 0%             0.000 ± 0%       ~ (p=1.000 n=6) ¹
NDJSONSerial/go-2.0.0.ndjson-16                                       9.237Mi ± 1%           9.219Mi ± 1%       ~ (p=0.394 n=6)
NDJSONSerial/nodejs-3.29.0.ndjson-16                                  5.564Mi ± 1%           5.576Mi ± 1%       ~ (p=0.818 n=6)
NDJSONSerial/python-6.7.2.ndjson-16                                   15.35Mi ± 1%           15.33Mi ± 0%       ~ (p=0.310 n=6)
NDJSONSerial/ruby-4.5.0.ndjson-16                                     8.254Mi ± 0%           8.249Mi ± 0%       ~ (p=0.589 n=6)
NDJSONParallel/go-2.0.0.ndjson-16                                     9.251Mi ± 0%           9.242Mi ± 1%       ~ (p=0.180 n=6)
NDJSONParallel/nodejs-3.29.0.ndjson-16                                5.562Mi ± 1%           5.599Mi ± 1%       ~ (p=0.132 n=6)
NDJSONParallel/python-6.7.2.ndjson-16                                 15.33Mi ± 0%           15.39Mi ± 0%       ~ (p=0.132 n=6)
NDJSONParallel/ruby-4.5.0.ndjson-16                                   8.248Mi ± 0%           8.249Mi ± 0%       ~ (p=0.589 n=6)
geomean                                                                            ²                       +0.14%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                       │ bench-out/merge-histogram-fastpath-7-before │ bench-out/merge-histogram-fastpath-7-after │
                                       │                  allocs/op                  │     allocs/op       vs base                │
AggregateCombinedMetrics-16                                             17.00 ± 0%             17.00 ± 0%       ~ (p=1.000 n=6) ¹
AggregateBatchSerial-16                                                 13.00 ± 0%             13.00 ± 0%       ~ (p=1.000 n=6) ¹
AggregateBatchParallel-16                                               13.00 ± 0%             13.00 ± 8%       ~ (p=0.455 n=6)
CombinedMetricsEncoding-16                                              0.000 ± 0%             0.000 ± 0%       ~ (p=1.000 n=6) ¹
CombinedMetricsToBatch-16                                               95.00 ± 0%             95.00 ± 0%       ~ (p=1.000 n=6) ¹
EventToCombinedMetrics-16                                               0.000 ± 0%             0.000 ± 0%       ~ (p=1.000 n=6) ¹
NDJSONSerial/go-2.0.0.ndjson-16                                        114.0k ± 3%            113.9k ± 2%       ~ (p=1.000 n=6)
NDJSONSerial/nodejs-3.29.0.ndjson-16                                   63.18k ± 1%            63.86k ± 1%       ~ (p=0.310 n=6)
NDJSONSerial/python-6.7.2.ndjson-16                                    162.7k ± 1%            163.3k ± 0%       ~ (p=0.132 n=6)
NDJSONSerial/ruby-4.5.0.ndjson-16                                      98.75k ± 0%            98.77k ± 1%       ~ (p=0.937 n=6)
NDJSONParallel/go-2.0.0.ndjson-16                                      113.8k ± 2%            114.2k ± 1%       ~ (p=0.394 n=6)
NDJSONParallel/nodejs-3.29.0.ndjson-16                                 63.45k ± 1%            64.15k ± 1%  +1.10% (p=0.015 n=6)
NDJSONParallel/python-6.7.2.ndjson-16                                  163.1k ± 1%            162.3k ± 1%       ~ (p=1.000 n=6)
NDJSONParallel/ruby-4.5.0.ndjson-16                                    98.78k ± 0%            98.88k ± 1%       ~ (p=0.485 n=6)
geomean                                                                            ²                       +0.18%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

```