### PR TITLE
perf: Add mergeHistogram fast path for single value from

### DIFF
--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -6,6 +6,7 @@ package aggregators
 
 import (
 	"io"
+	"sort"
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/cespare/xxhash/v2"
@@ -396,8 +397,49 @@ func mergeHistogram(to, from *aggregationpb.HDRHistogram) {
 		return
 	}
 
-	var toIdx, fromIdx int
 	toLen, fromLen := len(to.Buckets), len(from.Buckets)
+	// Heuristics to decide whether to use the fast path.
+	if fromLen < (toLen>>1) && from.Buckets[0] >= to.Buckets[0] && from.Buckets[fromLen-1] <= to.Buckets[toLen-1] {
+		// Fast path to optimize for cases where len(from.Buckets) << len(to.Buckets)
+		// Binary search for all from.Buckets in to.Buckets for fewer comparisons,
+		// mergeHistogram will be O(M lg N) where M = fromLen and N = toLen.
+		searchToLen := toLen
+		var fallback bool
+		for fromIdx := fromLen - 1; fromIdx >= 0; fromIdx-- {
+			// Instead of searching in to.Buckets[0:toLen] each time,
+			// make use of the result of the previous pass since from.Buckets[i] > from.Buckets[i-1],
+			// such that the search space can be reduced to to.Buckets[0:searchToLen].
+			fromVal := from.Buckets[fromIdx]
+			toIdx, found := sort.Find(searchToLen, func(toIdx int) int {
+				return int(fromVal - to.Buckets[toIdx])
+			})
+			if !found {
+				fallback = true
+				break
+			}
+
+			to.Counts[toIdx] += from.Counts[fromIdx]
+			from.Counts[fromIdx] = 0
+			// Invariants:
+			// to.Buckets[toIdx] == from.Buckets[fromIdx] (because we fallback immediately when not found)
+			// from.Buckets[i-1] < from.Buckets[i] (buckets are strictly increasing)
+			// to.Buckets[i-1] < to.Buckets[i]  (buckets are strictly increasing)
+			//
+			// Therefore:
+			// from.Buckets[fromIdx-1] < to.Buckets[toIdx]
+			// In the next pass, we can safely search in to.Buckets[0:toIdx], i.e. calling sort.Find(toIdx, ...).
+			// Edge case: where from.Buckets[fromIdx-1] > to.Buckets[toIdx-1], sort.Find will return (toIdx, false).
+			searchToLen = toIdx
+		}
+		if !fallback {
+			// from.Buckets is a subset of to.Buckets.
+			// No further merging is needed.
+			return
+		}
+	}
+
+	// Single pass O(N + M) merge.
+	var toIdx, fromIdx int
 	for toIdx, fromIdx = 0, 0; toIdx < toLen && fromIdx < fromLen; toIdx++ {
 		v := from.Buckets[fromIdx] - to.Buckets[toIdx]
 		switch {

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -421,26 +421,52 @@ func mergeHistogram(to, from *aggregationpb.HDRHistogram) {
 		return
 	}
 
-	// Single pass O(N + M) merge.
-	var toIdx, fromIdx int
-	for toIdx, fromIdx = 0, 0; toIdx < toLen && fromIdx < fromLen; toIdx++ {
-		v := from.Buckets[fromIdx] - to.Buckets[toIdx]
+	requiredLen := toLen + fromLen
+	for toIdx, fromIdx := 0, 0; toIdx < toLen && fromIdx < fromLen; {
+		v := to.Buckets[toIdx] - from.Buckets[fromIdx]
+		switch {
+		case v == 0:
+			// For every bucket that is common, we need one less bucket in final slice
+			requiredLen--
+			toIdx++
+			fromIdx++
+		case v < 0:
+			toIdx++
+		case v > 0:
+			fromIdx++
+		}
+	}
+
+	toIdx, fromIdx := toLen-1, fromLen-1
+	to.Buckets = slices.Grow(to.Buckets, requiredLen-toLen)[:requiredLen]
+	to.Counts = slices.Grow(to.Counts, requiredLen-toLen)[:requiredLen]
+	for idx := len(to.Buckets) - 1; idx >= 0; idx-- {
+		if fromIdx < 0 {
+			break
+		}
+		if toIdx < 0 {
+			to.Counts[idx] = from.Counts[fromIdx]
+			to.Buckets[idx] = from.Buckets[fromIdx]
+			fromIdx--
+			continue
+		}
+		v := to.Buckets[toIdx] - from.Buckets[fromIdx]
 		switch {
 		case v == 0:
 			to.Counts[toIdx] += from.Counts[fromIdx]
-			fromIdx++
-		case v < 0: // to.Buckets[toIdx] > from.Buckets[fromIdx]
-			to.Buckets[toIdx], from.Buckets[fromIdx] = from.Buckets[fromIdx], to.Buckets[toIdx]
-			to.Counts[toIdx], from.Counts[fromIdx] = from.Counts[fromIdx], to.Counts[toIdx]
+			to.Counts[idx] = to.Counts[toIdx]
+			to.Buckets[idx] = to.Buckets[toIdx]
+			toIdx--
+			fromIdx--
 		case v > 0:
+			to.Counts[idx] = to.Counts[toIdx]
+			to.Buckets[idx] = to.Buckets[toIdx]
+			toIdx--
+		case v < 0:
+			to.Counts[idx] = from.Counts[fromIdx]
+			to.Buckets[idx] = from.Buckets[fromIdx]
+			fromIdx--
 		}
-	}
-	extra := fromLen - fromIdx
-	if extra > 0 {
-		to.Buckets = slices.Grow(to.Buckets, extra)[:toLen+extra]
-		to.Counts = slices.Grow(to.Counts, extra)[:toLen+extra]
-		copy(to.Buckets[toLen:], from.Buckets[fromIdx:])
-		copy(to.Counts[toLen:], from.Counts[fromIdx:])
 	}
 }
 

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -429,7 +429,7 @@ func mergeHistogram(to, from *aggregationpb.HDRHistogram) {
 		case v == 0:
 			to.Counts[toIdx] += from.Counts[fromIdx]
 			fromIdx++
-		case v < 0:
+		case v < 0: // to.Buckets[toIdx] > from.Buckets[fromIdx]
 			to.Buckets[toIdx], from.Buckets[fromIdx] = from.Buckets[fromIdx], to.Buckets[toIdx]
 			to.Counts[toIdx], from.Counts[fromIdx] = from.Counts[fromIdx], to.Counts[toIdx]
 		case v > 0:

--- a/aggregators/merger_test.go
+++ b/aggregators/merger_test.go
@@ -1115,6 +1115,36 @@ func TestMergeHistogramEquiv(t *testing.T) {
 				}
 			},
 		},
+		// There may be special fast paths for single value from,
+		// and since we get them quite often,
+		// we have the following test cases for it.
+		{
+			name: "random_to_single_value_from_hit",
+			recordFunc: func(h1, h2 *hdrhistogram.HistogramRepresentation) {
+				var v, c int64
+				for i := 0; i < 1_000_000; i++ {
+					v = rand.Int63n(3_600_000_000)
+					c = rand.Int63n(1_000)
+					h1.RecordValues(v, c)
+				}
+				c = rand.Int63n(1_000)
+				h2.RecordValues(v, c)
+			},
+		},
+		{
+			name: "random_to_single_value_from_miss",
+			recordFunc: func(h1, h2 *hdrhistogram.HistogramRepresentation) {
+				for i := 0; i < 1_000_000; i++ {
+					v := rand.Int63n(3_600_000_000)
+					c := rand.Int63n(1_000)
+					h1.RecordValues(v, c)
+
+				}
+				v := rand.Int63n(3_600_000_000)
+				c := rand.Int63n(1_000)
+				h2.RecordValues(v, c)
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test assumes histogram representation Merge is correct
@@ -1190,7 +1220,7 @@ func TestMergeHistogram(t *testing.T) {
 			},
 		},
 		{
-			name: "single_value_exist",
+			name: "single_value_from_hit",
 			to: &aggregationpb.HDRHistogram{
 				Buckets: []int32{1, 2, 3},
 				Counts:  []int64{1, 2, 3},
@@ -1205,7 +1235,7 @@ func TestMergeHistogram(t *testing.T) {
 			},
 		},
 		{
-			name: "single_value_not_exist",
+			name: "single_value_from_miss",
 			to: &aggregationpb.HDRHistogram{
 				Buckets: []int32{1, 2, 4},
 				Counts:  []int64{1, 2, 4},

--- a/aggregators/merger_test.go
+++ b/aggregators/merger_test.go
@@ -1219,6 +1219,21 @@ func TestMergeHistogram(t *testing.T) {
 				Counts:  []int64{1},
 			},
 		},
+		{
+			name: "single_from_exist",
+			to: &aggregationpb.HDRHistogram{
+				Buckets: []int32{1000, 2000, 3000},
+				Counts:  []int64{1, 2, 3},
+			},
+			from: &aggregationpb.HDRHistogram{
+				Buckets: []int32{3000},
+				Counts:  []int64{4},
+			},
+			expected: &aggregationpb.HDRHistogram{
+				Buckets: []int32{1000, 2000, 3000},
+				Counts:  []int64{1, 2, 7},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			mergeHistogram(tc.to, tc.from)

--- a/aggregators/merger_test.go
+++ b/aggregators/merger_test.go
@@ -1145,48 +1145,18 @@ func TestMergeHistogram(t *testing.T) {
 		expected *aggregationpb.HDRHistogram
 	}{
 		{
-			name: "from_between_to",
+			name: "non_single_value",
 			to: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 3000},
-				Counts:  []int64{1, 3},
+				Buckets: []int32{1, 3, 5, 7, 9},
+				Counts:  []int64{1, 3, 5, 7, 9},
 			},
 			from: &aggregationpb.HDRHistogram{
-				Buckets: []int32{2000},
-				Counts:  []int64{2},
+				Buckets: []int32{2, 4, 5, 8},
+				Counts:  []int64{2, 4, 5, 8},
 			},
 			expected: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 2000, 3000},
-				Counts:  []int64{1, 2, 3},
-			},
-		},
-		{
-			name: "to_between_from",
-			to: &aggregationpb.HDRHistogram{
-				Buckets: []int32{2000},
-				Counts:  []int64{2},
-			},
-			from: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 3000},
-				Counts:  []int64{1, 3},
-			},
-			expected: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 2000, 3000},
-				Counts:  []int64{1, 2, 3},
-			},
-		},
-		{
-			name: "merge_counts",
-			to: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 2000},
-				Counts:  []int64{1, 2},
-			},
-			from: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 2000},
-				Counts:  []int64{1, 2},
-			},
-			expected: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 2000},
-				Counts:  []int64{2, 4},
+				Buckets: []int32{1, 2, 3, 4, 5, 7, 8, 9},
+				Counts:  []int64{1, 2, 3, 4, 10, 7, 8, 9},
 			},
 		},
 		{
@@ -1196,18 +1166,18 @@ func TestMergeHistogram(t *testing.T) {
 				Counts:  []int64{},
 			},
 			from: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000},
+				Buckets: []int32{1},
 				Counts:  []int64{1},
 			},
 			expected: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000},
+				Buckets: []int32{1},
 				Counts:  []int64{1},
 			},
 		},
 		{
 			name: "empty_from",
 			to: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000},
+				Buckets: []int32{1},
 				Counts:  []int64{1},
 			},
 			from: &aggregationpb.HDRHistogram{
@@ -1215,23 +1185,38 @@ func TestMergeHistogram(t *testing.T) {
 				Counts:  []int64{},
 			},
 			expected: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000},
+				Buckets: []int32{1},
 				Counts:  []int64{1},
 			},
 		},
 		{
-			name: "single_from_exist",
+			name: "single_value_exist",
 			to: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 2000, 3000},
+				Buckets: []int32{1, 2, 3},
 				Counts:  []int64{1, 2, 3},
 			},
 			from: &aggregationpb.HDRHistogram{
-				Buckets: []int32{3000},
+				Buckets: []int32{3},
 				Counts:  []int64{4},
 			},
 			expected: &aggregationpb.HDRHistogram{
-				Buckets: []int32{1000, 2000, 3000},
+				Buckets: []int32{1, 2, 3},
 				Counts:  []int64{1, 2, 7},
+			},
+		},
+		{
+			name: "single_value_not_exist",
+			to: &aggregationpb.HDRHistogram{
+				Buckets: []int32{1, 2, 4},
+				Counts:  []int64{1, 2, 4},
+			},
+			from: &aggregationpb.HDRHistogram{
+				Buckets: []int32{3},
+				Counts:  []int64{3},
+			},
+			expected: &aggregationpb.HDRHistogram{
+				Buckets: []int32{1, 2, 3, 4},
+				Counts:  []int64{1, 2, 3, 4},
 			},
 		},
 	} {


### PR DESCRIPTION
Optimize mergeHistogram for single value in `from` histogram, since it will be the majority case.

Alternative to #66. 

Also attached benchstat of BenchmarkMergeHistogram. It is a microbenchmark that measures time to merge single value `from` histogram to `to` histogram of size `size` and whether that the single value already exists in `to.Buckets`. It is not super well written and possibly only useful for this time. Therefore I've not included it in the change, but only attaching it in this PR description.

benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                             │ bench-out/merge-histogram-fastpath-8-before │ bench-out/merge-histogram-fastpath-8-after │
                                             │                   sec/op                    │       sec/op         vs base               │
AggregateCombinedMetrics-16                                                    1.890µ ± 6%         1.878µ ±   5%        ~ (p=0.699 n=6)
AggregateBatchSerial-16                                                        4.454µ ± 3%         4.403µ ± 144%        ~ (p=0.818 n=6)
AggregateBatchParallel-16                                                      5.087µ ± 5%         5.036µ ±   3%        ~ (p=0.589 n=6)
CombinedMetricsEncoding-16                                                     870.7n ± 3%         922.9n ±   4%   +6.00% (p=0.004 n=6)
CombinedMetricsToBatch-16                                                      60.60µ ± 4%         64.23µ ±   4%   +6.00% (p=0.004 n=6)
EventToCombinedMetrics-16                                                      394.3n ± 3%         387.4n ±   3%        ~ (p=0.225 n=6)
NDJSONSerial/go-2.0.0.ndjson-16                                                17.07m ± 4%         14.99m ±   4%  -12.19% (p=0.002 n=6)
NDJSONSerial/nodejs-3.29.0.ndjson-16                                           9.765m ± 3%         8.874m ±   5%   -9.12% (p=0.002 n=6)
NDJSONSerial/python-6.7.2-labels.ndjson-16                                     38.70m ± 4%         39.76m ±   4%        ~ (p=0.093 n=6)
NDJSONSerial/python-6.7.2.ndjson-16                                            23.12m ± 4%         23.01m ±   3%        ~ (p=0.589 n=6)
NDJSONSerial/ruby-4.5.0.ndjson-16                                              14.14m ± 5%         13.17m ±   8%   -6.85% (p=0.015 n=6)
NDJSONParallel/go-2.0.0.ndjson-16                                              16.80m ± 4%         15.09m ±   4%  -10.17% (p=0.002 n=6)
NDJSONParallel/nodejs-3.29.0.ndjson-16                                         9.664m ± 4%         8.792m ±   5%   -9.02% (p=0.002 n=6)
NDJSONParallel/python-6.7.2-labels.ndjson-16                                   40.45m ± 5%         39.31m ±   3%        ~ (p=0.240 n=6)
NDJSONParallel/python-6.7.2.ndjson-16                                          24.08m ± 9%         24.01m ±   5%        ~ (p=0.485 n=6)
NDJSONParallel/ruby-4.5.0.ndjson-16                                            14.27m ± 4%         13.20m ±   6%   -7.45% (p=0.009 n=6)
geomean                                                                        710.7µ              688.2µ          -3.16%

                                             │ bench-out/merge-histogram-fastpath-8-before │ bench-out/merge-histogram-fastpath-8-after │
                                             │                    B/op                     │        B/op         vs base                │
AggregateCombinedMetrics-16                                                 1.104Ki ± 1%           1.107Ki ± 0%       ~ (p=0.387 n=6)
AggregateBatchSerial-16                                                     1.373Ki ± 2%           1.349Ki ± 2%  -1.74% (p=0.037 n=6)
AggregateBatchParallel-16                                                   1.367Ki ± 1%           1.373Ki ± 1%       ~ (p=0.372 n=6)
CombinedMetricsEncoding-16                                                    0.000 ± 0%             0.000 ± 0%       ~ (p=1.000 n=6) ¹
CombinedMetricsToBatch-16                                                   3.982Ki ± 0%           3.981Ki ± 0%       ~ (p=0.550 n=6)
EventToCombinedMetrics-16                                                     0.000 ± 0%             0.000 ± 0%       ~ (p=1.000 n=6) ¹
NDJSONSerial/go-2.0.0.ndjson-16                                             9.235Mi ± 0%           9.249Mi ± 0%       ~ (p=0.310 n=6)
NDJSONSerial/nodejs-3.29.0.ndjson-16                                        5.570Mi ± 1%           5.555Mi ± 1%       ~ (p=1.000 n=6)
NDJSONSerial/python-6.7.2-labels.ndjson-16                                  29.95Mi ± 1%           30.02Mi ± 1%       ~ (p=0.699 n=6)
NDJSONSerial/python-6.7.2.ndjson-16                                         15.39Mi ± 1%           15.35Mi ± 0%       ~ (p=0.310 n=6)
NDJSONSerial/ruby-4.5.0.ndjson-16                                           8.249Mi ± 0%           8.253Mi ± 0%       ~ (p=0.485 n=6)
NDJSONParallel/go-2.0.0.ndjson-16                                           9.232Mi ± 0%           9.230Mi ± 1%       ~ (p=0.937 n=6)
NDJSONParallel/nodejs-3.29.0.ndjson-16                                      5.558Mi ± 1%           5.566Mi ± 1%       ~ (p=0.818 n=6)
NDJSONParallel/python-6.7.2-labels.ndjson-16                                30.06Mi ± 1%           29.92Mi ± 1%       ~ (p=0.180 n=6)
NDJSONParallel/python-6.7.2.ndjson-16                                       15.30Mi ± 1%           15.37Mi ± 0%       ~ (p=0.240 n=6)
NDJSONParallel/ruby-4.5.0.ndjson-16                                         8.251Mi ± 0%           8.253Mi ± 0%       ~ (p=0.818 n=6)
geomean                                                                                  ²                       -0.06%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                             │ bench-out/merge-histogram-fastpath-8-before │ bench-out/merge-histogram-fastpath-8-after │
                                             │                  allocs/op                  │     allocs/op       vs base                │
AggregateCombinedMetrics-16                                                   17.00 ± 0%             17.00 ± 0%       ~ (p=1.000 n=6) ¹
AggregateBatchSerial-16                                                       13.00 ± 0%             13.00 ± 8%       ~ (p=1.000 n=6)
AggregateBatchParallel-16                                                     13.00 ± 8%             13.00 ± 8%       ~ (p=1.000 n=6)
CombinedMetricsEncoding-16                                                    0.000 ± 0%             0.000 ± 0%       ~ (p=1.000 n=6) ¹
CombinedMetricsToBatch-16                                                     95.00 ± 0%             95.00 ± 0%       ~ (p=1.000 n=6) ¹
EventToCombinedMetrics-16                                                     0.000 ± 0%             0.000 ± 0%       ~ (p=1.000 n=6) ¹
NDJSONSerial/go-2.0.0.ndjson-16                                              114.6k ± 1%            114.0k ± 0%       ~ (p=0.485 n=6)
NDJSONSerial/nodejs-3.29.0.ndjson-16                                         63.15k ± 2%            63.50k ± 1%       ~ (p=0.485 n=6)
NDJSONSerial/python-6.7.2-labels.ndjson-16                                   326.3k ± 1%            326.3k ± 1%       ~ (p=0.937 n=6)
NDJSONSerial/python-6.7.2.ndjson-16                                          163.4k ± 0%            162.6k ± 2%       ~ (p=0.180 n=6)
NDJSONSerial/ruby-4.5.0.ndjson-16                                            98.69k ± 0%            99.01k ± 1%       ~ (p=0.065 n=6)
NDJSONParallel/go-2.0.0.ndjson-16                                            113.8k ± 1%            114.0k ± 1%       ~ (p=0.818 n=6)
NDJSONParallel/nodejs-3.29.0.ndjson-16                                       62.87k ± 1%            63.96k ± 1%  +1.72% (p=0.009 n=6)
NDJSONParallel/python-6.7.2-labels.ndjson-16                                 326.3k ± 1%            328.1k ± 1%       ~ (p=0.394 n=6)
NDJSONParallel/python-6.7.2.ndjson-16                                        162.3k ± 1%            162.9k ± 1%       ~ (p=0.589 n=6)
NDJSONParallel/ruby-4.5.0.ndjson-16                                          98.77k ± 0%            98.86k ± 0%       ~ (p=0.589 n=6)
geomean                                                                                  ²                       +0.18%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

MergeHistogram benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-aggregation/aggregators
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                               │ bench-out/merge-histogram-main │  bench-out/merge-histogram-bench-9  │
                               │             sec/op             │    sec/op     vs base               │
MergeHistogram/100-false-16                        148.45n ± 1%   93.07n ±  7%  -37.31% (p=0.002 n=6)
MergeHistogram/100-true-16                         174.10n ± 3%   75.12n ±  2%  -56.85% (p=0.002 n=6)
MergeHistogram/1000-false-16                       1113.0n ± 2%   437.8n ± 10%  -60.67% (p=0.002 n=6)
MergeHistogram/1000-true-16                        1373.0n ± 4%   162.2n ±  4%  -88.19% (p=0.002 n=6)
MergeHistogram/10000-false-16                      12.181µ ± 1%   4.998µ ±  3%  -58.97% (p=0.002 n=6)
MergeHistogram/10000-true-16                       14.437µ ± 2%   2.009µ ±  2%  -86.08% (p=0.002 n=6)
MergeHistogram/100000-false-16                     148.13µ ± 3%   75.81µ ±  4%  -48.82% (p=0.002 n=6)
MergeHistogram/100000-true-16                      171.57µ ± 2%   46.72µ ±  5%  -72.77% (p=0.002 n=6)
geomean                                             4.527µ        1.432µ        -68.38%

                               │ bench-out/merge-histogram-main │ bench-out/merge-histogram-bench-9  │
                               │              B/op              │    B/op     vs base                │
MergeHistogram/100-false-16                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/100-true-16                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/1000-false-16                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/1000-true-16                        0.000 ±  ?     0.000 ± 0%       ~ (p=1.000 n=6)
MergeHistogram/10000-false-16                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/10000-true-16                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/100000-false-16                     0.000 ± 0%     0.000 ±  ?       ~ (p=1.000 n=6)
MergeHistogram/100000-true-16                      0.000 ±  ?     0.000 ± 0%       ~ (p=1.000 n=6)
geomean                                                       ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                               │ bench-out/merge-histogram-main │ bench-out/merge-histogram-bench-9  │
                               │           allocs/op            │ allocs/op   vs base                │
MergeHistogram/100-false-16                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/100-true-16                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/1000-false-16                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/1000-true-16                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/10000-false-16                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/10000-true-16                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/100000-false-16                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
MergeHistogram/100000-true-16                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                       ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Benchmark function:
```go
func BenchmarkMergeHistogram(b *testing.B) {
	factor := 10
	for _, tc := range []struct {
		size int
	}{
		{
			size: 100,
		},
		{
			size: 1000,
		},
		{
			size: 10000,
		},
		{
			size: 100000,
		},
	} {
		for _, hit := range []bool{false, true} {
			b.Run(fmt.Sprintf("%d-%v", tc.size, hit), func(b *testing.B) {
				baseBuckets := make([]int32, tc.size)
				baseCounts := make([]int64, tc.size)

				for i := 0; i < tc.size; i++ {
					r := rand.Int31n(int32(factor))
					if i == 0 {
						baseBuckets[i] = r
					} else {
						baseBuckets[i] = baseBuckets[i-1] + r
					}
					baseCounts[i] = int64(r)
				}

				buckets := make([]int32, tc.size+1)
				counts := make([]int64, tc.size+1)

				to := aggregationpb.HDRHistogram{
					Buckets: buckets,
					Counts:  counts,
				}
				from := aggregationpb.HDRHistogram{
					Buckets: []int32{0},
					Counts:  []int64{1},
				}
				b.ResetTimer()

				for i := 0; i < b.N; i++ {
					copy(counts[:], baseCounts[:])
					copy(buckets[:], baseBuckets[:])
					to.Buckets = buckets[:tc.size]
					to.Counts = counts[:tc.size]
					if hit {
						from.Buckets[0] = to.Buckets[rand.Intn(tc.size)]
					} else {
						from.Buckets[0] = rand.Int31n(int32(tc.size * factor))
					}
					mergeHistogram(&to, &from)
				}
			})
		}
	}
}
```
