### PR TITLE
Add method to get combined metrics key without partition

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -457,8 +457,8 @@ func (a *Aggregator) harvestForInterval(
 		Interval:       ivl,
 		ProcessingTime: end,
 	}
-	lb := make([]byte, from.SizeBinary())
-	ub := make([]byte, to.SizeBinary())
+	lb := make([]byte, CombinedMetricsKeyEncodedSize)
+	ub := make([]byte, CombinedMetricsKeyEncodedSize)
 	from.MarshalBinaryToSizedBuffer(lb)
 	to.MarshalBinaryToSizedBuffer(ub)
 

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -616,9 +616,8 @@ func TestCombinedMetricsKeyOrdered(t *testing.T) {
 		Interval:       ivl,
 		ID:             cmID,
 	}
-	marshaledBufferSize := before.SizeBinary()
-	beforeBytes := make([]byte, marshaledBufferSize)
-	afterBytes := make([]byte, marshaledBufferSize)
+	beforeBytes := make([]byte, CombinedMetricsKeyEncodedSize)
+	afterBytes := make([]byte, CombinedMetricsKeyEncodedSize)
 
 	for i := 0; i < 10; i++ {
 		ts = ts.Add(time.Minute)
@@ -668,9 +667,8 @@ func TestCombinedMetricsKeyOrderedByProjectID(t *testing.T) {
 	}
 
 	before := keys[0]
-	marshaledBufferSize := before.SizeBinary()
-	beforeBytes := make([]byte, marshaledBufferSize)
-	afterBytes := make([]byte, marshaledBufferSize)
+	beforeBytes := make([]byte, CombinedMetricsKeyEncodedSize)
+	afterBytes := make([]byte, CombinedMetricsKeyEncodedSize)
 
 	for i := 1; i < len(keys); i++ {
 		ts = ts.Add(time.Minute)

--- a/aggregators/codec_test.go
+++ b/aggregators/codec_test.go
@@ -23,11 +23,32 @@ func TestCombinedMetricsKey(t *testing.T) {
 		ProcessingTime: time.Now().Truncate(time.Minute),
 		ID:             EncodeToCombinedMetricsKeyID(t, "ab01"),
 	}
-	data := make([]byte, expected.SizeBinary())
+	data := make([]byte, CombinedMetricsKeyEncodedSize)
 	assert.NoError(t, expected.MarshalBinaryToSizedBuffer(data))
 	var actual CombinedMetricsKey
 	assert.NoError(t, (&actual).UnmarshalBinary(data))
 	assert.Empty(t, cmp.Diff(expected, actual))
+}
+
+func TestGetEncodedCombinedMetricsKeyWithoutPartitionID(t *testing.T) {
+	key := CombinedMetricsKey{
+		Interval:       time.Minute,
+		ProcessingTime: time.Now().Truncate(time.Minute),
+		ID:             EncodeToCombinedMetricsKeyID(t, "ab01"),
+		PartitionID:    11,
+	}
+	var encoded [CombinedMetricsKeyEncodedSize]byte
+	assert.NoError(t, key.MarshalBinaryToSizedBuffer(encoded[:]))
+
+	key.PartitionID = 0
+	var expected [CombinedMetricsKeyEncodedSize]byte
+	assert.NoError(t, key.MarshalBinaryToSizedBuffer(expected[:]))
+
+	assert.Equal(
+		t,
+		expected[:],
+		GetEncodedCombinedMetricsKeyWithoutPartitionID(encoded[:]),
+	)
 }
 
 func TestGlobalLabels(t *testing.T) {


### PR DESCRIPTION
Adds a constant `CombinedMetricsKeyEncodedSize` to represent the size of encoded combined metrics key. This can be used to prevent allocations caused by `make` for `CombinedMetricsKey` decoding/encoding. Since it is an exposed value, if in future we move to variable length encoded combined metrics key that would result in a breaking change however, I don't think that should happen.

Adds a util method `GetEncodedCombinedMetricsKeyWithoutPartitionID` to strip an encoded combined metrics key of its partition. Added it here since it will be easy to maintain here if the logic changes in future. 