### PR TITLE
Fix incorrect size estimation on global overflow

### DIFF
--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -401,6 +401,15 @@ func CombinedMetricsToBatch(
 	// service_summary overflow metric
 	if len(cm.OverflowServiceInstancesEstimator) > 0 {
 		batchSize++
+		if len(cm.OverflowServices.OverflowTransactionsEstimator) > 0 {
+			batchSize++
+		}
+		if len(cm.OverflowServices.OverflowServiceTransactionsEstimator) > 0 {
+			batchSize++
+		}
+		if len(cm.OverflowServices.OverflowSpansEstimator) > 0 {
+			batchSize++
+		}
 	}
 
 	for _, ksm := range cm.ServiceMetrics {
@@ -437,7 +446,7 @@ func CombinedMetricsToBatch(
 			var gl GlobalLabels
 			err := gl.UnmarshalBinary(sik.GlobalLabelsStr)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to unmarshal global labels: %w", err)
 			}
 			getBaseEventWithLabels := func() *modelpb.APMEvent {
 				event := getBaseEvent(sk)


### PR DESCRIPTION
Prior to this PR, the code was not accounting for metrics added due to global overflow for txn, service txn, and span metric during size estimation for the batch before converting the harvested `CombinedMetrics` to batch of `APMEvent`s.