### PR TITLE
Emit service summary metric for all events

### DIFF
--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -419,8 +419,22 @@ func TestAggregateSpanMetrics(t *testing.T) {
 			inputs: []input{
 				{serviceName: "service-A", agentName: "java", outcome: "success", representativeCount: 1},
 			},
-			getExpectedEvents: func(_ time.Time, _, _ time.Duration, _ int) []*modelpb.APMEvent {
-				return nil
+			getExpectedEvents: func(ts time.Time, duration, ivl time.Duration, _ int) []*modelpb.APMEvent {
+				return []*modelpb.APMEvent{
+					{
+						Timestamp: timestamppb.New(ts.Truncate(ivl)),
+						Agent:     &modelpb.Agent{Name: "java"},
+						Service: &modelpb.Service{
+							Name: "service-A",
+						},
+						Metricset: &modelpb.Metricset{
+							Name:     "service_summary",
+							Interval: formatDuration(ivl),
+						},
+						Labels:        defaultLabels,
+						NumericLabels: defaultNumericLabels,
+					},
+				}
 			},
 		}, {
 			name: "with no destination and a service target",

--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -359,6 +359,9 @@ func EventToCombinedMetrics(
 
 	pmb.processEvent(e)
 	if len(pmb.builders) == 0 {
+		// This is unexpected state as any APMEvent must result in atleast the
+		// service summary metric. If such a state happens then it would indicate
+		// a bug in `processEvent`.
 		return fmt.Errorf("service summary metric must be produced for any event")
 	}
 

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -66,7 +66,16 @@ func TestEventToCombinedMetrics(t *testing.T) {
 			},
 			partitions: 1,
 			expected: func() []*aggregationpb.CombinedMetrics {
-				return nil
+				return []*aggregationpb.CombinedMetrics{
+					NewTestCombinedMetrics(
+						WithEventsTotal(1),
+						WithYoungestEventTimestamp(receivedTS)).
+						AddServiceMetrics(serviceAggregationKey{
+							Timestamp:   ts.Truncate(time.Minute),
+							ServiceName: "test"}).
+						AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+						GetProto(),
+				}
 			},
 		},
 		{
@@ -114,7 +123,16 @@ func TestEventToCombinedMetrics(t *testing.T) {
 			},
 			partitions: 1,
 			expected: func() []*aggregationpb.CombinedMetrics {
-				return nil
+				return []*aggregationpb.CombinedMetrics{
+					NewTestCombinedMetrics(
+						WithEventsTotal(1),
+						WithYoungestEventTimestamp(receivedTS)).
+						AddServiceMetrics(serviceAggregationKey{
+							Timestamp:   ts.Truncate(time.Minute),
+							ServiceName: "test"}).
+						AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+						GetProto(),
+				}
 			},
 		},
 		{
@@ -130,7 +148,16 @@ func TestEventToCombinedMetrics(t *testing.T) {
 			},
 			partitions: 1,
 			expected: func() []*aggregationpb.CombinedMetrics {
-				return nil
+				return []*aggregationpb.CombinedMetrics{
+					NewTestCombinedMetrics(
+						WithEventsTotal(1),
+						WithYoungestEventTimestamp(receivedTS)).
+						AddServiceMetrics(serviceAggregationKey{
+							Timestamp:   ts.Truncate(time.Minute),
+							ServiceName: "test"}).
+						AddServiceInstanceMetrics(serviceInstanceAggregationKey{}).
+						GetProto(),
+				}
 			},
 		},
 		{


### PR DESCRIPTION
Before this PR, we didn't emit service summary metric in following cases:

1. When the representative count for input transaction/span is zero
2. When span event is not an exit span

With this PR, we emit service summary metric for all events.