### PR TITLE
Update apm-data for uint64 event duration

### DIFF
--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -32,7 +32,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/elastic/apm-aggregation/aggregationpb"
 	"github.com/elastic/apm-aggregation/aggregators/internal/hdrhistogram"
@@ -68,7 +67,7 @@ func TestAggregateBatch(t *testing.T) {
 		batch = append(batch, &modelpb.APMEvent{
 			Event: &modelpb.Event{
 				Outcome:  "success",
-				Duration: durationpb.New(eventDuration),
+				Duration: uint64(eventDuration),
 				Received: modelpb.FromTime(ts),
 			},
 			Transaction: &modelpb.Transaction{
@@ -81,7 +80,7 @@ func TestAggregateBatch(t *testing.T) {
 						Outcome:                    "success",
 						Duration: &modelpb.AggregatedDuration{
 							Count: 1,
-							Sum:   durationpb.New(dssDuration),
+							Sum:   uint64(dssDuration),
 						},
 					},
 				},
@@ -90,7 +89,7 @@ func TestAggregateBatch(t *testing.T) {
 		})
 		batch = append(batch, &modelpb.APMEvent{
 			Event: &modelpb.Event{
-				Duration: durationpb.New(eventDuration),
+				Duration: uint64(eventDuration),
 				Received: modelpb.FromTime(ts),
 			},
 			Span: &modelpb.Span{
@@ -320,7 +319,7 @@ func TestAggregateSpanMetrics(t *testing.T) {
 								Resource: destinationX,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: uint64(count),
-									Sum:   durationpb.New(time.Duration(count) * duration),
+									Sum:   uint64(time.Duration(count) * duration),
 								},
 							},
 						},
@@ -348,7 +347,7 @@ func TestAggregateSpanMetrics(t *testing.T) {
 								Resource: destinationZ,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: uint64(count),
-									Sum:   durationpb.New(time.Duration(count) * duration),
+									Sum:   uint64(time.Duration(count) * duration),
 								},
 							},
 						},
@@ -376,7 +375,7 @@ func TestAggregateSpanMetrics(t *testing.T) {
 								Resource: destinationZ,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: uint64(3 * count),
-									Sum:   durationpb.New(time.Duration(3*count) * duration),
+									Sum:   uint64(time.Duration(3*count) * duration),
 								},
 							},
 						},
@@ -404,7 +403,7 @@ func TestAggregateSpanMetrics(t *testing.T) {
 								Resource: destinationZ,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: uint64(count),
-									Sum:   durationpb.New(time.Duration(count) * duration),
+									Sum:   uint64(time.Duration(count) * duration),
 								},
 							},
 						},
@@ -475,7 +474,7 @@ func TestAggregateSpanMetrics(t *testing.T) {
 							DestinationService: &modelpb.DestinationService{
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: uint64(count),
-									Sum:   durationpb.New(time.Duration(count) * duration),
+									Sum:   uint64(time.Duration(count) * duration),
 								},
 							},
 						},
@@ -521,7 +520,7 @@ func TestAggregateSpanMetrics(t *testing.T) {
 								Resource: destinationZ,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: uint64(count),
-									Sum:   durationpb.New(time.Duration(count) * duration),
+									Sum:   uint64(time.Duration(count) * duration),
 								},
 							},
 						},
@@ -844,7 +843,7 @@ func TestAggregateAndHarvest(t *testing.T) {
 		{
 			Event: &modelpb.Event{
 				Outcome:  "success",
-				Duration: durationpb.New(txnDuration),
+				Duration: uint64(txnDuration),
 			},
 			Transaction: &modelpb.Transaction{
 				Name:                "foo",
@@ -1022,7 +1021,7 @@ func TestRunStopOrchestration(t *testing.T) {
 			EncodeToCombinedMetricsKeyID(t, "ab01"),
 			&modelpb.Batch{
 				&modelpb.APMEvent{
-					Event: &modelpb.Event{Duration: durationpb.New(time.Millisecond)},
+					Event: &modelpb.Event{Duration: uint64(time.Millisecond)},
 					Transaction: &modelpb.Transaction{
 						Name:                "T-1000",
 						Type:                "type",
@@ -1201,7 +1200,7 @@ func newTestAggregator(tb testing.TB) *Aggregator {
 func newTestBatchForBenchmark() *modelpb.Batch {
 	return &modelpb.Batch{
 		&modelpb.APMEvent{
-			Event: &modelpb.Event{Duration: durationpb.New(time.Millisecond)},
+			Event: &modelpb.Event{Duration: uint64(time.Millisecond)},
 			Transaction: &modelpb.Transaction{
 				Name:                "T-1000",
 				Type:                "type",
@@ -1330,7 +1329,7 @@ func makeSpan(
 		Service:   &modelpb.Service{Name: serviceName},
 		Event: &modelpb.Event{
 			Outcome:  outcome,
-			Duration: durationpb.New(duration),
+			Duration: uint64(duration),
 		},
 		Span: &modelpb.Span{
 			Name:                serviceName + ":" + destinationServiceResource,

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/elastic/apm-aggregation/aggregationpb"
 	"github.com/elastic/apm-aggregation/aggregators/internal/hdrhistogram"
@@ -31,7 +30,7 @@ func TestEventToCombinedMetrics(t *testing.T) {
 		ParentId:  "nonroot",
 		Service:   &modelpb.Service{Name: "test"},
 		Event: &modelpb.Event{
-			Duration: durationpb.New(time.Second),
+			Duration: uint64(time.Second),
 			Outcome:  "success",
 			Received: modelpb.FromTime(receivedTS),
 		},
@@ -173,7 +172,7 @@ func TestEventToCombinedMetrics(t *testing.T) {
 					Type: "db",
 				}
 				// Current test structs are hardcoded to use 1ns for spans
-				event.Event.Duration = durationpb.New(time.Nanosecond)
+				event.Event.Duration = uint64(time.Nanosecond)
 				return []*modelpb.APMEvent{event}
 			},
 			partitions: 1,
@@ -208,7 +207,7 @@ func TestEventToCombinedMetrics(t *testing.T) {
 					},
 				}
 				// Current test structs are hardcoded to use 1ns for spans
-				event.Event.Duration = durationpb.New(time.Nanosecond)
+				event.Event.Duration = uint64(time.Nanosecond)
 				return []*modelpb.APMEvent{event}
 			},
 			partitions: 1,
@@ -555,7 +554,7 @@ func BenchmarkEventToCombinedMetrics(b *testing.B) {
 			Name: "test",
 		},
 		Event: &modelpb.Event{
-			Duration: durationpb.New(time.Second),
+			Duration: uint64(time.Second),
 			Outcome:  "success",
 		},
 		Transaction: &modelpb.Transaction{
@@ -759,7 +758,7 @@ func createTestSpanMetric(
 				ResponseTime: &modelpb.AggregatedDuration{
 					// test code generates 1 count for 1 ns
 					Count: uint64(count),
-					Sum:   durationpb.New(time.Duration(count)),
+					Sum:   uint64(time.Duration(count)),
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/axiomhq/hyperloglog v0.0.0-20230201085229-3ddf4bad03dc
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cockroachdb/pebble v0.0.0-20230627193317-c807f60529a3
-	github.com/elastic/apm-data v0.1.1-0.20230809075845-a636758ca08d
+	github.com/elastic/apm-data v0.1.1-0.20230814023104-48e4b20579f6
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
 	go.elastic.co/apm/module/apmotel/v2 v2.4.3

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsY
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
-github.com/elastic/apm-data v0.1.1-0.20230809075845-a636758ca08d h1:JMqKWDy0qdlVaiNyIbEtLj8twT0r/61LJVZ9F2IaR08=
-github.com/elastic/apm-data v0.1.1-0.20230809075845-a636758ca08d/go.mod h1:lMTMoCWNadiDJih/tLechuMTtumEeedtKJlBOYAv030=
+github.com/elastic/apm-data v0.1.1-0.20230814023104-48e4b20579f6 h1:ixw/vSYEKysrW8xl8gcKEo443dySneWvKjtzsOq893s=
+github.com/elastic/apm-data v0.1.1-0.20230814023104-48e4b20579f6/go.mod h1:lMTMoCWNadiDJih/tLechuMTtumEeedtKJlBOYAv030=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=
 github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=


### PR DESCRIPTION
Update to uint64-based durations -- https://github.com/elastic/apm-data/pull/142