### PR TITLE
Add logging for overflow

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -575,16 +575,6 @@ func (a *Aggregator) harvestForInterval(
 	return cmCount, err
 }
 
-type harvestStats struct {
-	eventsTotal            float64
-	youngestEventTimestamp time.Time
-
-	servicesOverflowed            uint64
-	transactionsOverflowed        uint64
-	serviceTransactionsOverflowed uint64
-	spansOverflowed               uint64
-}
-
 func (a *Aggregator) processHarvest(
 	ctx context.Context,
 	cmk CombinedMetricsKey,
@@ -603,9 +593,13 @@ func (a *Aggregator) processHarvest(
 	hs := harvestStats{
 		eventsTotal:            cm.EventsTotal,
 		youngestEventTimestamp: modelpb.ToTime(cm.YoungestEventTimestamp),
+		servicesOverflowed:     hllSketchEstimate(cm.OverflowServicesEstimator),
 	}
-
-	a.getAndLogOverflowStats(&hs, cm, aggIvl)
+	overflowLogger := nopLogger
+	if a.cfg.OverflowLogging {
+		overflowLogger = a.cfg.Logger.With(zap.Duration("aggregation_interval_ns", aggIvl))
+	}
+	hs.addOverflows(cm, a.cfg.Limits, overflowLogger)
 
 	if err := a.cfg.Processor(ctx, cmk, cm, aggIvl); err != nil {
 		return harvestStats{}, fmt.Errorf("failed to process combined metrics ID %s: %w", cmk.ID, err)
@@ -613,124 +607,142 @@ func (a *Aggregator) processHarvest(
 	return hs, nil
 }
 
-func (a *Aggregator) getAndLogOverflowStats(hs *harvestStats, cm *aggregationpb.CombinedMetrics, aggIvl time.Duration) {
-	hs.servicesOverflowed = hllSketchEstimate(cm.OverflowServicesEstimator)
+var (
+	nopLogger = zap.NewNop()
 
-	logFunc := func(msg string, fields ...zap.Field) {
-		if a.cfg.OverflowLogging.Func != nil &&
-			(a.cfg.OverflowLogging.AggregationInterval == 0 || a.cfg.OverflowLogging.AggregationInterval == aggIvl) {
-			a.cfg.OverflowLogging.Func(msg, fields...)
+	// TODO(carsonip): Update this log message when global labels implementation changes
+	serviceGroupLimitReachedMessage = fmt.Sprintf(""+
+		"Service limit reached, new metric documents will be grouped under a dedicated "+
+		"overflow bucket identified by service name '%s'. "+
+		"If you are sending global labels that are request-specific (e.g. client IP), it may cause "+
+		"high cardinality and lead to exhaustion of services.",
+		overflowBucketName,
+	)
+
+	transactionGroupLimitReachedMessage = "" +
+		"Transaction group per service limit reached, " + transactionGroupLimitReachedSuffix
+	overallTransactionGroupLimitReachedMessage = "" +
+		"Overall transaction group limit reached, " + transactionGroupLimitReachedSuffix
+	transactionGroupLimitReachedSuffix = fmt.Sprintf(""+
+		"new metric documents will be grouped under a dedicated bucket identified by transaction name '%s'. "+
+		"This is typically caused by ineffective transaction grouping, "+
+		"e.g. by creating many unique transaction names. "+
+		"If you are using an agent with 'use_path_as_transaction_name' enabled, it may cause "+
+		"high cardinality. If your agent supports the 'transaction_name_groups' option, setting "+
+		"that configuration option appropriately, may lead to better results.",
+		overflowBucketName,
+	)
+
+	serviceTransactionGroupLimitReachedMessage = fmt.Sprintf(""+
+		"Service transaction group per service limit reached, new metric documents will be grouped "+
+		"under a dedicated bucket identified by transaction type '%s'.",
+		overflowBucketName,
+	)
+	overallServiceTransactionGroupLimitReachedMessage = fmt.Sprintf(""+
+		"Overall service transaction group limit reached, new metric documents will be grouped "+
+		"under a dedicated bucket identified by transaction type '%s'.",
+		overflowBucketName,
+	)
+
+	spanGroupLimitReachedMessage = fmt.Sprintf(""+
+		"Span group per service limit reached, new metric documents will be grouped "+
+		"under a dedicated bucket identified by service target name '%s'.",
+		overflowBucketName,
+	)
+	overallSpanGroupLimitReachedMessage = fmt.Sprintf(""+
+		"Overall span group limit reached, new metric documents will be grouped "+
+		"under a dedicated bucket identified by service target name '%s'.",
+		overflowBucketName,
+	)
+)
+
+type harvestStats struct {
+	eventsTotal            float64
+	youngestEventTimestamp time.Time
+
+	servicesOverflowed            uint64
+	transactionsOverflowed        uint64
+	serviceTransactionsOverflowed uint64
+	spansOverflowed               uint64
+}
+
+func (hs *harvestStats) addOverflows(cm *aggregationpb.CombinedMetrics, limits Limits, logger *zap.Logger) {
+	if hs.servicesOverflowed != 0 {
+		logger.Warn(serviceGroupLimitReachedMessage, zap.Int("limit", limits.MaxServices))
+	}
+
+	// Flags to indicate the overall limit reached per aggregation type,
+	// so that they are only logged once.
+	var loggedOverallTransactionGroupLimitReached bool
+	var loggedOverallServiceTransactionGroupLimitReached bool
+	var loggedOverallSpanGroupLimitReached bool
+	logLimitReached := func(
+		n, limit int,
+		serviceKey *aggregationpb.ServiceAggregationKey,
+		perServiceMessage string,
+		overallMessage string,
+		loggedOverallMessage *bool,
+	) {
+		if serviceKey == nil {
+			// serviceKey will be nil for the service overflow,
+			// which is due to cardinality service keys, not
+			// metric keys.
+			return
+		}
+		if n >= limit {
+			logger.Warn(
+				perServiceMessage,
+				zap.String("service_name", serviceKey.GetServiceName()),
+				zap.Int("limit", limit),
+			)
+			return
+		} else if !*loggedOverallMessage {
+			logger.Warn(overallMessage, zap.Int("limit", limit))
+			*loggedOverallMessage = true
 		}
 	}
 
-	// TODO(carsonip): Update this log message when global labels implementation changes
-	logFunc(fmt.Sprintf(""+
-		"Service limit reached, new metric documents will be grouped under a dedicated "+
-		"overflow bucket identified by service name '%s'. "+
-		"If you are sending global labels that are user-specific (e.g. client IP), it may cause "+
-		"high cardinality and lead to exhaustion of services.", overflowBucketName),
-		zap.Duration("aggregation_interval_ns", aggIvl),
-		zap.Int("limit", a.cfg.Limits.MaxServices),
-	)
-
-	// Flags to indicate global / "overall" limit reached per aggregation so that they are only logged once.
-	var txOverflowLogged, svcTxOverflowLogged, spanOverflowLogged bool
-
-	addOverflow := func(serviceName string, o *aggregationpb.Overflow, txGroups, svcTxGroups, spanGroups int) {
+	addOverflow := func(o *aggregationpb.Overflow, ksm *aggregationpb.KeyedServiceMetrics) {
 		if o == nil {
 			return
 		}
 		if overflowed := hllSketchEstimate(o.OverflowTransactionsEstimator); overflowed > 0 {
 			hs.transactionsOverflowed += overflowed
-			if serviceName != overflowBucketName {
-				if txGroups >= a.cfg.Limits.MaxTransactionGroupsPerService {
-					logFunc(fmt.Sprintf(""+
-						"Transaction group per service limit reached, "+
-						"new metric documents will be grouped under a dedicated bucket identified by transaction name '%s'. "+
-						"This is typically caused by ineffective transaction grouping, "+
-						"e.g. by creating many unique transaction names. "+
-						"If you are using an agent with 'use_path_as_transaction_name' enabled, it may cause "+
-						"high cardinality. If your agent supports the 'transaction_name_groups' option, setting "+
-						"that configuration option appropriately, may lead to better results.", overflowBucketName),
-						zap.String("service_name", serviceName),
-						zap.Duration("aggregation_interval_ns", aggIvl),
-						zap.Int("limit", a.cfg.Limits.MaxTransactionGroupsPerService),
-					)
-				} else if !txOverflowLogged {
-					logFunc(fmt.Sprintf(""+
-						"Overall transaction group limit reached, "+
-						"new metric documents will be grouped under a dedicated bucket identified by transaction name '%s'. "+
-						"This is typically caused by ineffective transaction grouping, "+
-						"e.g. by creating many unique transaction names. "+
-						"If you are using an agent with 'use_path_as_transaction_name' enabled, it may cause "+
-						"high cardinality. If your agent supports the 'transaction_name_groups' option, setting "+
-						"that configuration option appropriately, may lead to better results.", overflowBucketName),
-						zap.Duration("aggregation_interval_ns", aggIvl),
-						zap.Int("limit", a.cfg.Limits.MaxTransactionGroups),
-					)
-					txOverflowLogged = true
-				}
-			}
+			logLimitReached(
+				len(ksm.GetMetrics().GetTransactionMetrics()),
+				limits.MaxTransactionGroupsPerService,
+				ksm.GetKey(),
+				transactionGroupLimitReachedMessage,
+				overallTransactionGroupLimitReachedMessage,
+				&loggedOverallTransactionGroupLimitReached,
+			)
 		}
-
 		if overflowed := hllSketchEstimate(o.OverflowServiceTransactionsEstimator); overflowed > 0 {
 			hs.serviceTransactionsOverflowed += overflowed
-			if serviceName != overflowBucketName {
-				if svcTxGroups >= a.cfg.Limits.MaxServiceTransactionGroupsPerService {
-					logFunc(fmt.Sprintf(""+
-						"Service transaction group per service limit reached, new metric documents will be grouped "+
-						"under a dedicated bucket identified by transaction type '%s'.", overflowBucketName),
-						zap.String("service_name", serviceName),
-						zap.Duration("aggregation_interval_ns", aggIvl),
-						zap.Int("limit", a.cfg.Limits.MaxServiceTransactionGroupsPerService),
-					)
-				} else if !svcTxOverflowLogged {
-					logFunc(fmt.Sprintf(""+
-						"Overall service transaction group limit reached, new metric documents will be grouped "+
-						"under a dedicated bucket identified by transaction type '%s'.", overflowBucketName),
-						zap.Duration("aggregation_interval_ns", aggIvl),
-						zap.Int("limit", a.cfg.Limits.MaxServiceTransactionGroups),
-					)
-					svcTxOverflowLogged = true
-				}
-			}
+			logLimitReached(
+				len(ksm.GetMetrics().GetServiceTransactionMetrics()),
+				limits.MaxServiceTransactionGroupsPerService,
+				ksm.GetKey(),
+				serviceTransactionGroupLimitReachedMessage,
+				overallServiceTransactionGroupLimitReachedMessage,
+				&loggedOverallServiceTransactionGroupLimitReached,
+			)
 		}
-
 		if overflowed := hllSketchEstimate(o.OverflowSpansEstimator); overflowed > 0 {
 			hs.spansOverflowed += overflowed
-			if serviceName != overflowBucketName {
-				if spanGroups >= a.cfg.Limits.MaxSpanGroupsPerService {
-					logFunc(fmt.Sprintf(""+
-						"Span group per service limit reached, new metric documents will be grouped "+
-						"under a dedicated bucket identified by service target name '%s'.", overflowBucketName),
-						zap.String("service_name", serviceName),
-						zap.Duration("aggregation_interval_ns", aggIvl),
-						zap.Int("limit", a.cfg.Limits.MaxSpanGroupsPerService),
-					)
-				} else if !spanOverflowLogged {
-					logFunc(fmt.Sprintf(""+
-						"Overall span group limit reached, new metric documents will be grouped "+
-						"under a dedicated bucket identified by service target name '%s'.", overflowBucketName),
-						zap.Duration("aggregation_interval_ns", aggIvl),
-						zap.Int("limit", a.cfg.Limits.MaxSpanGroups),
-					)
-					spanOverflowLogged = true
-				}
-			}
+			logLimitReached(
+				len(ksm.GetMetrics().GetSpanMetrics()),
+				limits.MaxSpanGroupsPerService,
+				ksm.GetKey(),
+				spanGroupLimitReachedMessage,
+				overallSpanGroupLimitReachedMessage,
+				&loggedOverallSpanGroupLimitReached,
+			)
 		}
 	}
 
-	// overflowService should be counted for metrics, but not logged since they only happen on
-	// service overflow.
-	addOverflow(overflowBucketName, cm.OverflowServices, 0, 0, 0)
-
+	addOverflow(cm.OverflowServices, nil)
 	for _, ksm := range cm.ServiceMetrics {
-		addOverflow(
-			ksm.GetKey().GetServiceName(),
-			ksm.GetMetrics().GetOverflowGroups(),
-			len(ksm.GetMetrics().GetTransactionMetrics()),
-			len(ksm.GetMetrics().GetServiceTransactionMetrics()),
-			len(ksm.GetMetrics().GetSpanMetrics()),
-		)
+		addOverflow(ksm.GetMetrics().GetOverflowGroups(), ksm)
 	}
 }

--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -622,9 +622,12 @@ func (a *Aggregator) getAndLogOverflowStats(hs *harvestStats, cm *aggregationpb.
 		}
 	}
 
+	// TODO(carsonip): Update this log message when global labels implementation changes
 	logFunc(fmt.Sprintf(""+
 		"Service limit reached, new metric documents will be grouped under a dedicated "+
-		"overflow bucket identified by service name '%s'.", overflowBucketName),
+		"overflow bucket identified by service name '%s'. "+
+		"If you are sending global labels that are user-specific (e.g. client IP), it may cause "+
+		"high cardinality and lead to exhaustion of services.", overflowBucketName),
 		zap.Duration("aggregation_interval_ns", aggIvl),
 		zap.Int("limit", a.cfg.Limits.MaxServices),
 	)

--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -617,8 +617,9 @@ func (a *Aggregator) getAndLogOverflowStats(hs *harvestStats, cm *aggregationpb.
 	hs.servicesOverflowed = hllSketchEstimate(cm.OverflowServicesEstimator)
 
 	logFunc := func(msg string, fields ...zap.Field) {
-		if a.cfg.OverflowLogFunc != nil {
-			a.cfg.OverflowLogFunc(msg, fields...)
+		if a.cfg.OverflowLogging.Func != nil &&
+			(a.cfg.OverflowLogging.AggregationInterval == 0 || a.cfg.OverflowLogging.AggregationInterval == aggIvl) {
+			a.cfg.OverflowLogging.Func(msg, fields...)
 		}
 	}
 

--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -715,7 +715,11 @@ func (a *Aggregator) getAndLogOverflowStats(hs *harvestStats, cm *aggregationpb.
 			}
 		}
 	}
+
+	// overflowService should be counted for metrics, but not logged since they only happen on
+	// service overflow.
 	addOverflow(overflowBucketName, cm.OverflowServices, 0, 0, 0)
+
 	for _, ksm := range cm.ServiceMetrics {
 		addOverflow(
 			ksm.GetKey().GetServiceName(),

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -1037,10 +1037,8 @@ func TestHarvestOverflowCount(t *testing.T) {
 			WithCombinedMetricsIDToKVs(func(id [16]byte) []attribute.KeyValue {
 				return []attribute.KeyValue{attribute.String("id_key", "id_value")}
 			}),
-			WithOverflowLogging(OverflowLogging{
-				Func:                observedLogger.Warn,
-				AggregationInterval: time.Minute,
-			}),
+			WithLogger(observedLogger),
+			WithOverflowLogging(true),
 		)
 
 		var batch modelpb.Batch

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -1037,7 +1037,10 @@ func TestHarvestOverflowCount(t *testing.T) {
 			WithCombinedMetricsIDToKVs(func(id [16]byte) []attribute.KeyValue {
 				return []attribute.KeyValue{attribute.String("id_key", "id_value")}
 			}),
-			WithOverflowLogFunc(observedLogger.Warn),
+			WithOverflowLogging(OverflowLogging{
+				Func:                observedLogger.Warn,
+				AggregationInterval: time.Minute,
+			}),
 		)
 
 		var batch modelpb.Batch

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -1037,10 +1037,7 @@ func TestHarvestOverflowCount(t *testing.T) {
 			WithCombinedMetricsIDToKVs(func(id [16]byte) []attribute.KeyValue {
 				return []attribute.KeyValue{attribute.String("id_key", "id_value")}
 			}),
-			WithOverflowLogger(OverflowLogger{
-				Logger:   observedLogger,
-				interval: time.Minute,
-			}),
+			WithOverflowLogFunc(observedLogger.Warn),
 		)
 
 		var batch modelpb.Batch

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -15,8 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/cockroachdb/pebble"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -32,6 +30,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -994,121 +994,186 @@ func TestAggregateAndHarvest(t *testing.T) {
 }
 
 func TestHarvestOverflowCount(t *testing.T) {
-	ivls := []time.Duration{time.Minute}
-	reader := metric.NewManualReader()
-	meter := metric.NewMeterProvider(metric.WithReader(reader)).Meter("test")
+	for _, tc := range []struct {
+		limits                Limits
+		expectedLogPerService bool
+	}{
+		{
+			limits: Limits{
+				MaxSpanGroups:                         4,
+				MaxSpanGroupsPerService:               4,
+				MaxTransactionGroups:                  3,
+				MaxTransactionGroupsPerService:        3,
+				MaxServiceTransactionGroups:           2,
+				MaxServiceTransactionGroupsPerService: 2,
+				MaxServices:                           1,
+			},
+			expectedLogPerService: true,
+		},
+		{
+			limits: Limits{
+				MaxSpanGroups:                         4,
+				MaxSpanGroupsPerService:               100,
+				MaxTransactionGroups:                  3,
+				MaxTransactionGroupsPerService:        100,
+				MaxServiceTransactionGroups:           2,
+				MaxServiceTransactionGroupsPerService: 100,
+				MaxServices:                           1,
+			},
+			expectedLogPerService: false,
+		},
+	} {
+		limits := tc.limits
+		ivls := []time.Duration{time.Minute}
+		reader := metric.NewManualReader()
+		meter := metric.NewMeterProvider(metric.WithReader(reader)).Meter("test")
 
-	limits := Limits{
-		MaxSpanGroups:                         4,
-		MaxSpanGroupsPerService:               4,
-		MaxTransactionGroups:                  3,
-		MaxTransactionGroupsPerService:        3,
-		MaxServiceTransactionGroups:           2,
-		MaxServiceTransactionGroupsPerService: 2,
-		MaxServices:                           1,
-	}
-	agg := newTestAggregator(t,
-		WithLimits(limits),
-		WithAggregationIntervals(ivls),
-		WithMeter(meter),
-		WithCombinedMetricsIDToKVs(func(id [16]byte) []attribute.KeyValue {
-			return []attribute.KeyValue{attribute.String("id_key", "id_value")}
-		}),
-	)
-
-	var batch modelpb.Batch
-	for i := 0; i < limits.MaxServices+1; i++ {
-		serviceName := fmt.Sprintf("service_name_%d", i)
-		for i := 0; i < limits.MaxTransactionGroups+1; i++ {
-			transactionName := fmt.Sprintf("transaction_name_%d", i)
-			transactionType := fmt.Sprintf(
-				"transaction_type_%d", i%(limits.MaxServiceTransactionGroups+1),
-			)
-			batch = append(batch, &modelpb.APMEvent{
-				Service: &modelpb.Service{Name: serviceName},
-				Transaction: &modelpb.Transaction{
-					Name:                transactionName,
-					Type:                transactionType,
-					RepresentativeCount: 1,
-				},
-			})
-		}
-		for i := 0; i < limits.MaxSpanGroups+1; i++ {
-			serviceTargetName := fmt.Sprintf("service_target_name_%d", i)
-			batch = append(batch, &modelpb.APMEvent{
-				Service: &modelpb.Service{
-					Name: serviceName,
-					Target: &modelpb.ServiceTarget{
-						Name: serviceTargetName,
-						Type: "service_target_type",
-					},
-				},
-				Span: &modelpb.Span{
-					Name:                "span_name",
-					Type:                "span_type",
-					RepresentativeCount: 1,
-				},
-			})
-		}
-	}
-	cmID := EncodeToCombinedMetricsKeyID(t, "cm_id")
-	require.NoError(t, agg.AggregateBatch(context.Background(), cmID, &batch))
-
-	// Force harvest.
-	require.NoError(t, agg.Close(context.Background()))
-
-	var resourceMetrics metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
-	require.Len(t, resourceMetrics.ScopeMetrics, 1)
-	scopeMetrics := resourceMetrics.ScopeMetrics[0]
-
-	expected := metricdata.Sum[int64]{
-		IsMonotonic: true,
-		Temporality: metricdata.CumulativeTemporality,
-		DataPoints: []metricdata.DataPoint[int64]{{
-			Attributes: attribute.NewSet(
-				attribute.String(aggregationIvlKey, "1m"),
-				attribute.String(aggregationTypeKey, "service"),
-				attribute.String("id_key", "id_value"),
-			),
-			Value: 1,
-		}, {
-			Attributes: attribute.NewSet(
-				attribute.String(aggregationIvlKey, "1m"),
-				attribute.String(aggregationTypeKey, "service_destination"),
-				attribute.String("id_key", "id_value"),
-			),
-			Value: int64(limits.MaxSpanGroups) + 2,
-		}, {
-			Attributes: attribute.NewSet(
-				attribute.String(aggregationIvlKey, "1m"),
-				attribute.String(aggregationTypeKey, "service_transaction"),
-				attribute.String("id_key", "id_value"),
-			),
-			Value: int64(limits.MaxServiceTransactionGroups) + 2,
-		}, {
-			Attributes: attribute.NewSet(
-				attribute.String(aggregationIvlKey, "1m"),
-				attribute.String(aggregationTypeKey, "transaction"),
-				attribute.String("id_key", "id_value"),
-			),
-			Value: int64(limits.MaxTransactionGroups) + 2,
-		}},
-	}
-
-	var found bool
-	for _, metric := range scopeMetrics.Metrics {
-		if metric.Name != "metrics.overflowed.count" {
-			continue
-		}
-		metricdatatest.AssertAggregationsEqual(
-			t, expected, metric.Data,
-			metricdatatest.IgnoreTimestamp(),
+		observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+		observedLogger := zap.New(observedZapCore)
+		agg := newTestAggregator(t,
+			WithLimits(limits),
+			WithAggregationIntervals(ivls),
+			WithMeter(meter),
+			WithCombinedMetricsIDToKVs(func(id [16]byte) []attribute.KeyValue {
+				return []attribute.KeyValue{attribute.String("id_key", "id_value")}
+			}),
+			WithOverflowLogger(OverflowLogger{
+				Logger:   observedLogger,
+				interval: time.Minute,
+			}),
 		)
-		found = true
-		break
+
+		var batch modelpb.Batch
+		for i := 0; i < limits.MaxServices+1; i++ {
+			serviceName := fmt.Sprintf("service_name_%d", i)
+			for i := 0; i < limits.MaxTransactionGroups+1; i++ {
+				transactionName := fmt.Sprintf("transaction_name_%d", i)
+				transactionType := fmt.Sprintf(
+					"transaction_type_%d", i%(limits.MaxServiceTransactionGroups+1),
+				)
+				batch = append(batch, &modelpb.APMEvent{
+					Service: &modelpb.Service{Name: serviceName},
+					Transaction: &modelpb.Transaction{
+						Name:                transactionName,
+						Type:                transactionType,
+						RepresentativeCount: 1,
+					},
+				})
+			}
+			for i := 0; i < limits.MaxSpanGroups+1; i++ {
+				serviceTargetName := fmt.Sprintf("service_target_name_%d", i)
+				batch = append(batch, &modelpb.APMEvent{
+					Service: &modelpb.Service{
+						Name: serviceName,
+						Target: &modelpb.ServiceTarget{
+							Name: serviceTargetName,
+							Type: "service_target_type",
+						},
+					},
+					Span: &modelpb.Span{
+						Name:                "span_name",
+						Type:                "span_type",
+						RepresentativeCount: 1,
+					},
+				})
+			}
+		}
+		cmID := EncodeToCombinedMetricsKeyID(t, "cm_id")
+		require.NoError(t, agg.AggregateBatch(context.Background(), cmID, &batch))
+
+		// Force harvest.
+		require.NoError(t, agg.Close(context.Background()))
+
+		var resourceMetrics metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
+		require.Len(t, resourceMetrics.ScopeMetrics, 1)
+		scopeMetrics := resourceMetrics.ScopeMetrics[0]
+
+		expected := metricdata.Sum[int64]{
+			IsMonotonic: true,
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints: []metricdata.DataPoint[int64]{{
+				Attributes: attribute.NewSet(
+					attribute.String(aggregationIvlKey, "1m"),
+					attribute.String(aggregationTypeKey, "service"),
+					attribute.String("id_key", "id_value"),
+				),
+				Value: 1,
+			}, {
+				Attributes: attribute.NewSet(
+					attribute.String(aggregationIvlKey, "1m"),
+					attribute.String(aggregationTypeKey, "service_destination"),
+					attribute.String("id_key", "id_value"),
+				),
+				Value: int64(limits.MaxSpanGroups) + 2,
+			}, {
+				Attributes: attribute.NewSet(
+					attribute.String(aggregationIvlKey, "1m"),
+					attribute.String(aggregationTypeKey, "service_transaction"),
+					attribute.String("id_key", "id_value"),
+				),
+				Value: int64(limits.MaxServiceTransactionGroups) + 2,
+			}, {
+				Attributes: attribute.NewSet(
+					attribute.String(aggregationIvlKey, "1m"),
+					attribute.String(aggregationTypeKey, "transaction"),
+					attribute.String("id_key", "id_value"),
+				),
+				Value: int64(limits.MaxTransactionGroups) + 2,
+			}},
+		}
+
+		var found bool
+		for _, metric := range scopeMetrics.Metrics {
+			if metric.Name != "metrics.overflowed.count" {
+				continue
+			}
+			metricdatatest.AssertAggregationsEqual(
+				t, expected, metric.Data,
+				metricdatatest.IgnoreTimestamp(),
+			)
+			found = true
+			break
+		}
+		assert.True(t, found)
+
+		assert.Len(t, observedLogs.Filter(func(entry observer.LoggedEntry) bool {
+			return strings.Contains(entry.Message, "Service limit reached")
+		}).All(), 1)
+
+		var expectedLogPerServiceCount, expectedGlobalLogCount int
+		if tc.expectedLogPerService {
+			expectedLogPerServiceCount = 1
+			expectedGlobalLogCount = 0
+		} else {
+			expectedLogPerServiceCount = 0
+			expectedGlobalLogCount = 1
+		}
+
+		assert.Len(t, observedLogs.Filter(func(entry observer.LoggedEntry) bool {
+			return strings.Contains(entry.Message, "Transaction group per service limit reached")
+		}).All(), expectedLogPerServiceCount)
+
+		assert.Len(t, observedLogs.Filter(func(entry observer.LoggedEntry) bool {
+			return strings.Contains(entry.Message, "Service transaction group per service limit reached")
+		}).All(), expectedLogPerServiceCount)
+
+		assert.Len(t, observedLogs.Filter(func(entry observer.LoggedEntry) bool {
+			return strings.Contains(entry.Message, "Span group per service limit reached")
+		}).All(), expectedLogPerServiceCount)
+
+		assert.Len(t, observedLogs.Filter(func(entry observer.LoggedEntry) bool {
+			return strings.Contains(entry.Message, "Overall transaction group limit reached")
+		}).All(), expectedGlobalLogCount)
+
+		assert.Len(t, observedLogs.Filter(func(entry observer.LoggedEntry) bool {
+			return strings.Contains(entry.Message, "Overall service transaction group limit reached")
+		}).All(), expectedGlobalLogCount)
+
+		assert.Len(t, observedLogs.Filter(func(entry observer.LoggedEntry) bool {
+			return strings.Contains(entry.Message, "Overall span group limit reached")
+		}).All(), expectedGlobalLogCount)
 	}
-	assert.True(t, found)
 }
 
 func TestRunStopOrchestration(t *testing.T) {

--- a/aggregators/config.go
+++ b/aggregators/config.go
@@ -34,13 +34,6 @@ type Processor func(
 	aggregationIvl time.Duration,
 ) error
 
-// OverflowLogging defines the logging function when overflow happens,
-// and for which aggregation interval is overflow logging enabled.
-type OverflowLogging struct {
-	Func                func(msg string, fields ...zap.Field)
-	AggregationInterval time.Duration
-}
-
 // Config contains the required config for running the aggregator.
 type Config struct {
 	DataDir                string
@@ -55,7 +48,7 @@ type Config struct {
 	Meter           metric.Meter
 	Tracer          trace.Tracer
 	Logger          *zap.Logger
-	OverflowLogging OverflowLogging
+	OverflowLogging bool
 }
 
 // Option allows configuring aggregator based on functional options.
@@ -182,10 +175,13 @@ func WithLogger(logger *zap.Logger) Option {
 	}
 }
 
-// WithOverflowLogging defines log function and aggregation interval for overflow logging.
-func WithOverflowLogging(logging OverflowLogging) Option {
+// WithOverflowLogging enables warning logs at harvest time, when overflows have occurred.
+//
+// Logging of overflows is disabled by default, as most callers are expected to rely on
+// metrics to surface cardinality issues. Support for logging exists for historical reasons.
+func WithOverflowLogging(enabled bool) Option {
 	return func(c Config) Config {
-		c.OverflowLogging = logging
+		c.OverflowLogging = enabled
 		return c
 	}
 }

--- a/aggregators/config.go
+++ b/aggregators/config.go
@@ -34,14 +34,6 @@ type Processor func(
 	aggregationIvl time.Duration,
 ) error
 
-// OverflowLogger is a wrapper over zap.Logger with a configurable interval.
-// If interval is zero, all intervals will be logged.
-// Otherwise, only the specified interval will be logged.
-type OverflowLogger struct {
-	*zap.Logger
-	interval time.Duration
-}
-
 // Config contains the required config for running the aggregator.
 type Config struct {
 	DataDir                string
@@ -53,10 +45,10 @@ type Config struct {
 	CombinedMetricsIDToKVs func([16]byte) []attribute.KeyValue
 	InMemory               bool
 
-	Meter          metric.Meter
-	Tracer         trace.Tracer
-	Logger         *zap.Logger
-	OverflowLogger OverflowLogger
+	Meter           metric.Meter
+	Tracer          trace.Tracer
+	Logger          *zap.Logger
+	OverflowLogFunc func(msg string, fields ...zap.Field)
 }
 
 // Option allows configuring aggregator based on functional options.
@@ -183,10 +175,10 @@ func WithLogger(logger *zap.Logger) Option {
 	}
 }
 
-// WithOverflowLogger defines a custom OverflowLogger for overflow reporting.
-func WithOverflowLogger(logger OverflowLogger) Option {
+// WithOverflowLogFunc defines log function for overflow logging.
+func WithOverflowLogFunc(logFunc func(msg string, fields ...zap.Field)) Option {
 	return func(c Config) Config {
-		c.OverflowLogger = logger
+		c.OverflowLogFunc = logFunc
 		return c
 	}
 }

--- a/aggregators/config.go
+++ b/aggregators/config.go
@@ -34,6 +34,13 @@ type Processor func(
 	aggregationIvl time.Duration,
 ) error
 
+// OverflowLogging defines the logging function when overflow happens,
+// and for which aggregation interval is overflow logging enabled.
+type OverflowLogging struct {
+	Func                func(msg string, fields ...zap.Field)
+	AggregationInterval time.Duration
+}
+
 // Config contains the required config for running the aggregator.
 type Config struct {
 	DataDir                string
@@ -48,7 +55,7 @@ type Config struct {
 	Meter           metric.Meter
 	Tracer          trace.Tracer
 	Logger          *zap.Logger
-	OverflowLogFunc func(msg string, fields ...zap.Field)
+	OverflowLogging OverflowLogging
 }
 
 // Option allows configuring aggregator based on functional options.
@@ -175,10 +182,10 @@ func WithLogger(logger *zap.Logger) Option {
 	}
 }
 
-// WithOverflowLogFunc defines log function for overflow logging.
-func WithOverflowLogFunc(logFunc func(msg string, fields ...zap.Field)) Option {
+// WithOverflowLogging defines log function and aggregation interval for overflow logging.
+func WithOverflowLogging(logging OverflowLogging) Option {
 	return func(c Config) Config {
-		c.OverflowLogFunc = logFunc
+		c.OverflowLogging = logging
 		return c
 	}
 }

--- a/aggregators/config.go
+++ b/aggregators/config.go
@@ -34,6 +34,14 @@ type Processor func(
 	aggregationIvl time.Duration,
 ) error
 
+// OverflowLogger is a wrapper over zap.Logger with a configurable interval.
+// If interval is zero, all intervals will be logged.
+// Otherwise, only the specified interval will be logged.
+type OverflowLogger struct {
+	*zap.Logger
+	interval time.Duration
+}
+
 // Config contains the required config for running the aggregator.
 type Config struct {
 	DataDir                string
@@ -45,9 +53,10 @@ type Config struct {
 	CombinedMetricsIDToKVs func([16]byte) []attribute.KeyValue
 	InMemory               bool
 
-	Meter  metric.Meter
-	Tracer trace.Tracer
-	Logger *zap.Logger
+	Meter          metric.Meter
+	Tracer         trace.Tracer
+	Logger         *zap.Logger
+	OverflowLogger OverflowLogger
 }
 
 // Option allows configuring aggregator based on functional options.
@@ -170,6 +179,14 @@ func WithCombinedMetricsIDToKVs(f func([16]byte) []attribute.KeyValue) Option {
 func WithLogger(logger *zap.Logger) Option {
 	return func(c Config) Config {
 		c.Logger = logger
+		return c
+	}
+}
+
+// WithOverflowLogger defines a custom OverflowLogger for overflow reporting.
+func WithOverflowLogger(logger OverflowLogger) Option {
+	return func(c Config) Config {
+		c.OverflowLogger = logger
 		return c
 	}
 }


### PR DESCRIPTION
Overflow logging is important for insight into aggregations and diagnosing high cardinality dimensions. This was in apm-server and we should retain this feature in apm-aggregation. Aggregator now accepts an optional logging function that will be called when overflow is present during harvest. Log messages will look similar to apm-server aggregation overflow log messages. As overflow can happen due to global limit or per-service limit breach, add additional logic in order to output meaningful and actionable logs.

Part of #75 