### PR TITLE
Always use full unmodified span key for cardinality estimation

### DIFF
--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -216,6 +216,7 @@ func mergeSpanGroups(
 		if !ok {
 			// Protect against agents that send high cardinality span names by dropping
 			// span.name if more than half of the per svc span group limit is reached.
+			originalSpanName := fromSpan.Key.SpanName
 			half := perSvcConstraint.Limit() / 2
 			if perSvcConstraint.Value() >= half {
 				spk.SpanName = ""
@@ -225,6 +226,9 @@ func mergeSpanGroups(
 			if !ok {
 				overflowed := perSvcConstraint.Maxed() || globalConstraint.Maxed()
 				if overflowed {
+					// Restore span name in case it was dropped above,
+					// for cardinality estimation.
+					fromSpan.Key.SpanName = originalSpanName
 					fromSpanKeyHash := protohash.HashSpanAggregationKey(hash, fromSpan.Key)
 					overflowTo.Merge(fromSpan.Metrics, fromSpanKeyHash.Sum64())
 					continue

--- a/aggregators/merger_test.go
+++ b/aggregators/merger_test.go
@@ -267,7 +267,7 @@ func TestMerge(t *testing.T) {
 						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
 					// all span, transaction, and service transaction from _from_ will overflow
-					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(5)).
+					AddSpanOverflow(spanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
 					AddServiceTransactionOverflow(
 						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).
@@ -355,7 +355,7 @@ func TestMerge(t *testing.T) {
 					AddTransaction(
 						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
-					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(10)).
+					AddSpanOverflow(spanAggregationKey{SpanName: "span2"}, WithSpanCount(10)).
 					AddServiceTransactionOverflow(
 						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(10)).
@@ -386,7 +386,7 @@ func TestMerge(t *testing.T) {
 					AddTransaction(
 						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
-					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(15)).
+					AddSpanOverflow(spanAggregationKey{SpanName: "span2"}, WithSpanCount(15)).
 					AddServiceTransactionOverflow(
 						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(15),
@@ -431,7 +431,7 @@ func TestMerge(t *testing.T) {
 					AddTransaction(
 						transactionAggregationKey{TransactionName: "txn2", TransactionType: "type2"},
 						WithTransactionCount(5)).
-					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(8)).
+					AddSpanOverflow(spanAggregationKey{SpanName: "span3"}, WithSpanCount(8)).
 					AddServiceTransactionOverflow(
 						serviceTransactionAggregationKey{TransactionType: "type3"},
 						WithTransactionCount(8)).
@@ -450,7 +450,8 @@ func TestMerge(t *testing.T) {
 					AddTransaction(
 						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
-					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(13)).
+					AddSpanOverflow(spanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
+					AddSpanOverflow(spanAggregationKey{SpanName: "span3"}, WithSpanCount(8)).
 					AddServiceTransactionOverflow(
 						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).
@@ -617,7 +618,7 @@ func TestMerge(t *testing.T) {
 					AddTransaction(
 						transactionAggregationKey{TransactionName: "txn1", TransactionType: "type1"},
 						WithTransactionCount(7)).
-					AddSpanOverflow(spanAggregationKey{SpanName: ""}, WithSpanCount(5)).
+					AddSpanOverflow(spanAggregationKey{SpanName: "span2"}, WithSpanCount(5)).
 					AddServiceTransactionOverflow(
 						serviceTransactionAggregationKey{TransactionType: "type2"},
 						WithTransactionCount(5)).


### PR DESCRIPTION
Always use the full unmodified span key for cardinality estimation. Therefore, restore span name in case it was dropped to reduce cardinality.

Closes #54 