### PR TITLE
ci: run go mod tidy and update imports after renovate bump

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -62,6 +62,10 @@
       "enabled": false
     }
   ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ],
   "automergeStrategy": "squash",
   "automergeType": "branch",
   "separateMajorMinor": true


### PR DESCRIPTION
Should fix failing renovate PRs

e.g. https://github.com/elastic/apm-aggregation/pull/93