### PR TITLE
fix: record and use overflow service instance transaction aggregation metrics

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -515,6 +515,7 @@ func (a *Aggregator) harvestForInterval(
 		}
 		recordMetricsOverflow(harvestStats.servicesOverflowed, "service")
 		recordMetricsOverflow(harvestStats.transactionsOverflowed, "transaction")
+		recordMetricsOverflow(harvestStats.serviceInstanceTransactionsOverflowed, "service_instance_transaction")
 		recordMetricsOverflow(harvestStats.serviceTransactionsOverflowed, "service_transaction")
 		recordMetricsOverflow(harvestStats.spansOverflowed, "service_destination")
 
@@ -633,6 +634,17 @@ var (
 		overflowBucketName,
 	)
 
+	serviceInstanceTransactionGroupLimitReachedMessage = fmt.Sprintf(""+
+		"Service instance transaction group per service limit reached, new metric documents will be grouped "+
+		"under a dedicated bucket identified by transaction type '%s'.",
+		overflowBucketName,
+	)
+	overallServiceInstanceTransactionGroupLimitReachedMessage = fmt.Sprintf(""+
+		"Overall service instance transaction group limit reached, new metric documents will be grouped "+
+		"under a dedicated bucket identified by transaction type '%s'.",
+		overflowBucketName,
+	)
+
 	serviceTransactionGroupLimitReachedMessage = fmt.Sprintf(""+
 		"Service transaction group per service limit reached, new metric documents will be grouped "+
 		"under a dedicated bucket identified by transaction type '%s'.",
@@ -660,10 +672,11 @@ type harvestStats struct {
 	eventsTotal            float64
 	youngestEventTimestamp time.Time
 
-	servicesOverflowed            uint64
-	transactionsOverflowed        uint64
-	serviceTransactionsOverflowed uint64
-	spansOverflowed               uint64
+	servicesOverflowed                    uint64
+	transactionsOverflowed                uint64
+	serviceTransactionsOverflowed         uint64
+	serviceInstanceTransactionsOverflowed uint64
+	spansOverflowed                       uint64
 }
 
 func (hs *harvestStats) addOverflows(cm *aggregationpb.CombinedMetrics, limits Limits, logger *zap.Logger) {
@@ -675,6 +688,7 @@ func (hs *harvestStats) addOverflows(cm *aggregationpb.CombinedMetrics, limits L
 	// so that they are only logged once.
 	var loggedOverallTransactionGroupLimitReached bool
 	var loggedOverallServiceTransactionGroupLimitReached bool
+	var loggedOverallServiceInstanceTransactionGroupLimitReached bool
 	var loggedOverallSpanGroupLimitReached bool
 	logLimitReached := func(
 		n, limit int,
@@ -715,6 +729,17 @@ func (hs *harvestStats) addOverflows(cm *aggregationpb.CombinedMetrics, limits L
 				transactionGroupLimitReachedMessage,
 				overallTransactionGroupLimitReachedMessage,
 				&loggedOverallTransactionGroupLimitReached,
+			)
+		}
+		if overflowed := hllSketchEstimate(o.OverflowServiceInstanceTransactionsEstimator); overflowed > 0 {
+			hs.serviceInstanceTransactionsOverflowed += overflowed
+			logLimitReached(
+				len(ksm.GetMetrics().GetServiceInstanceTransactionMetrics()),
+				limits.MaxServiceInstanceTransactionGroupsPerService,
+				ksm.GetKey(),
+				serviceInstanceTransactionGroupLimitReachedMessage,
+				overallServiceInstanceTransactionGroupLimitReachedMessage,
+				&loggedOverallServiceInstanceTransactionGroupLimitReached,
 			)
 		}
 		if overflowed := hllSketchEstimate(o.OverflowServiceTransactionsEstimator); overflowed > 0 {

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -1196,6 +1196,13 @@ func TestHarvestOverflowCount(t *testing.T) {
 			}, {
 				Attributes: attribute.NewSet(
 					attribute.String(aggregationIvlKey, "1m"),
+					attribute.String(aggregationTypeKey, "service_instance_transaction"),
+					attribute.String("id_key", "id_value"),
+				),
+				Value: int64(limits.MaxServiceInstanceTransactionGroups) + 2,
+			}, {
+				Attributes: attribute.NewSet(
+					attribute.String(aggregationIvlKey, "1m"),
 					attribute.String(aggregationTypeKey, "service_transaction"),
 					attribute.String("id_key", "id_value"),
 				),


### PR DESCRIPTION
record and use overflow service instance transaction aggregation metrics

Update test to account for service instance transaction metrics and add a log message for overflow