### PR TITLE
Introduce max lookback period

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -428,7 +428,7 @@ func (a *Aggregator) harvest(
 	for _, ivl := range a.cfg.AggregationIntervals {
 		// Check if the given aggregation interval needs to be harvested now
 		if end.Truncate(ivl).Equal(end) {
-			start := end.Add(-ivl)
+			start := end.Add(-ivl).Add(-a.cfg.MaxLookback)
 			cmCount, err := a.harvestForInterval(
 				ctx, snap, start, end, ivl, cachedEventsStats[ivl],
 			)

--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -428,7 +428,7 @@ func (a *Aggregator) harvest(
 	for _, ivl := range a.cfg.AggregationIntervals {
 		// Check if the given aggregation interval needs to be harvested now
 		if end.Truncate(ivl).Equal(end) {
-			start := end.Add(-ivl).Add(-a.cfg.MaxLookback)
+			start := end.Add(-ivl).Add(-a.cfg.Lookback)
 			cmCount, err := a.harvestForInterval(
 				ctx, snap, start, end, ivl, cachedEventsStats[ivl],
 			)

--- a/aggregators/aggregator_test.go
+++ b/aggregators/aggregator_test.go
@@ -648,6 +648,170 @@ func TestAggregateSpanMetrics(t *testing.T) {
 	}
 }
 
+func TestAggregateCombinedMetrics(t *testing.T) {
+	aggIvl := time.Second
+	now := time.Now().Truncate(aggIvl)
+	cmkID := EncodeToCombinedMetricsKeyID(t, "ab01")
+	input := []*TestCombinedMetrics{
+		NewTestCombinedMetrics(
+			WithEventsTotal(1),
+			// Key with very old processing time will be dropped if
+			// it is not within max lookback period.
+			WithKey(CombinedMetricsKey{
+				Interval:       aggIvl,
+				ProcessingTime: now.Add(-time.Hour),
+				ID:             cmkID,
+			}),
+		).AddServiceMetrics(serviceAggregationKey{
+			Timestamp:   now,
+			ServiceName: "test-svc",
+		}).AddTransaction(transactionAggregationKey{
+			TransactionName: "txntestold",
+			TransactionType: "txntypeold",
+		}).AddServiceTransaction(serviceTransactionAggregationKey{
+			TransactionType: "txntypeold",
+		}).GetTest(),
+
+		NewTestCombinedMetrics(
+			WithEventsTotal(1),
+			WithKey(CombinedMetricsKey{
+				Interval:       aggIvl,
+				ProcessingTime: now,
+				ID:             cmkID,
+			}),
+		).AddServiceMetrics(serviceAggregationKey{
+			Timestamp:   now,
+			ServiceName: "test-svc",
+		}).AddTransaction(transactionAggregationKey{
+			TransactionName: "txntest",
+			TransactionType: "txntype",
+		}).AddServiceTransaction(serviceTransactionAggregationKey{
+			TransactionType: "txntype",
+		}).GetTest(),
+
+		NewTestCombinedMetrics(
+			WithEventsTotal(1),
+			WithKey(CombinedMetricsKey{
+				Interval:       aggIvl,
+				ProcessingTime: now,
+				ID:             cmkID,
+			}),
+		).AddServiceMetrics(serviceAggregationKey{
+			Timestamp:   now,
+			ServiceName: "test-svc",
+		}).AddSpan(spanAggregationKey{
+			SpanName:   "spantest",
+			TargetType: "db",
+			TargetName: "test",
+		}, WithSpanDuration(time.Second), WithSpanCount(100)).GetTest(),
+	}
+
+	for _, tc := range []struct {
+		name     string
+		cfgOpts  []Option
+		expected []*aggregationpb.CombinedMetrics
+	}{
+		{
+			name: "without_max_lookback",
+			expected: []*aggregationpb.CombinedMetrics{
+				NewTestCombinedMetrics(WithEventsTotal(2)).
+					AddServiceMetrics(serviceAggregationKey{
+						Timestamp:   now,
+						ServiceName: "test-svc",
+					}).
+					AddSpan(spanAggregationKey{
+						SpanName:   "spantest",
+						TargetType: "db",
+						TargetName: "test",
+					}, WithSpanDuration(time.Second), WithSpanCount(100)).
+					AddTransaction(transactionAggregationKey{
+						TransactionName: "txntest",
+						TransactionType: "txntype",
+					}).
+					AddServiceTransaction(serviceTransactionAggregationKey{
+						TransactionType: "txntype",
+					}).GetProto(),
+			},
+		},
+		{
+			name:    "with_max_lookback",
+			cfgOpts: []Option{WithMaxLookback(2 * time.Hour)},
+			expected: []*aggregationpb.CombinedMetrics{
+				NewTestCombinedMetrics(WithEventsTotal(1)).
+					AddServiceMetrics(serviceAggregationKey{
+						Timestamp:   now,
+						ServiceName: "test-svc",
+					}).
+					AddTransaction(transactionAggregationKey{
+						TransactionName: "txntestold",
+						TransactionType: "txntypeold",
+					}).
+					AddServiceTransaction(serviceTransactionAggregationKey{
+						TransactionType: "txntypeold",
+					}).GetProto(),
+
+				NewTestCombinedMetrics(WithEventsTotal(2)).
+					AddServiceMetrics(serviceAggregationKey{
+						Timestamp:   now,
+						ServiceName: "test-svc",
+					}).
+					AddSpan(spanAggregationKey{
+						SpanName:   "spantest",
+						TargetType: "db",
+						TargetName: "test",
+					}, WithSpanDuration(time.Second), WithSpanCount(100)).
+					AddTransaction(transactionAggregationKey{
+						TransactionName: "txntest",
+						TransactionType: "txntype",
+					}).
+					AddServiceTransaction(serviceTransactionAggregationKey{
+						TransactionType: "txntype",
+					}).GetProto(),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var output []*aggregationpb.CombinedMetrics
+			agg, err := New(append(
+				tc.cfgOpts,
+				WithDataDir(t.TempDir()),
+				WithAggregationIntervals([]time.Duration{aggIvl}),
+				WithProcessor(combinedMetricsSliceProcessor(&output)),
+				WithLimits(Limits{
+					MaxServices:                           100,
+					MaxSpanGroups:                         100,
+					MaxSpanGroupsPerService:               100,
+					MaxTransactionGroups:                  100,
+					MaxTransactionGroupsPerService:        100,
+					MaxServiceTransactionGroups:           100,
+					MaxServiceTransactionGroupsPerService: 100,
+				}),
+				WithHarvestDelay(time.Hour),
+			)...)
+			require.NoError(t, err)
+
+			for _, tcm := range input {
+				err := agg.AggregateCombinedMetrics(context.Background(), tcm.GetKey(), tcm.GetProto())
+				require.NoError(t, err)
+			}
+			require.NoError(t, agg.Close(context.Background()))
+
+			assert.Empty(t, cmp.Diff(
+				tc.expected,
+				output,
+				append(combinedMetricsSliceSorters,
+					cmpopts.EquateEmpty(),
+					cmpopts.EquateApprox(0, 0.01),
+					cmp.Comparer(func(a, b hdrhistogram.HybridCountsRep) bool {
+						return a.Equal(&b)
+					}),
+					protocmp.Transform(),
+				)...,
+			))
+		})
+	}
+}
+
 func TestCombinedMetricsKeyOrdered(t *testing.T) {
 	// To Allow for retrieving combined metrics by time range, the metrics should
 	// be ordered by processing time.
@@ -1434,6 +1598,18 @@ func combinedMetricsProcessor(out chan<- *aggregationpb.CombinedMetrics) Process
 		_ time.Duration,
 	) error {
 		out <- cm.CloneVT()
+		return nil
+	}
+}
+
+func combinedMetricsSliceProcessor(slice *[]*aggregationpb.CombinedMetrics) Processor {
+	return func(
+		_ context.Context,
+		_ CombinedMetricsKey,
+		cm *aggregationpb.CombinedMetrics,
+		_ time.Duration,
+	) error {
+		*slice = append(*slice, cm.CloneVT())
 		return nil
 	}
 }

--- a/aggregators/combined_metrics_test.go
+++ b/aggregators/combined_metrics_test.go
@@ -18,11 +18,19 @@ import (
 )
 
 type TestCombinedMetricsCfg struct {
+	key                    CombinedMetricsKey
 	eventsTotal            float64
 	youngestEventTimestamp time.Time
 }
 
 type TestCombinedMetricsOpt func(cfg TestCombinedMetricsCfg) TestCombinedMetricsCfg
+
+func WithKey(key CombinedMetricsKey) TestCombinedMetricsOpt {
+	return func(cfg TestCombinedMetricsCfg) TestCombinedMetricsCfg {
+		cfg.key = key
+		return cfg
+	}
+}
 
 func WithEventsTotal(total float64) TestCombinedMetricsOpt {
 	return func(cfg TestCombinedMetricsCfg) TestCombinedMetricsCfg {
@@ -114,7 +122,10 @@ var defaultTestSpanCfg = TestSpanCfg{
 // TestCombinedMetrics creates combined metrics for testing. The creation logic
 // is arranged in a way to allow chained creation and addition of leaf nodes
 // to combined metrics.
-type TestCombinedMetrics combinedMetrics
+type TestCombinedMetrics struct {
+	key   CombinedMetricsKey
+	value *combinedMetrics
+}
 
 func NewTestCombinedMetrics(opts ...TestCombinedMetricsOpt) *TestCombinedMetrics {
 	cfg := defaultTestCombinedMetricsCfg
@@ -125,18 +136,22 @@ func NewTestCombinedMetrics(opts ...TestCombinedMetricsOpt) *TestCombinedMetrics
 	cm.EventsTotal = cfg.eventsTotal
 	cm.YoungestEventTimestamp = modelpb.FromTime(cfg.youngestEventTimestamp)
 	cm.Services = make(map[serviceAggregationKey]serviceMetrics)
-	return (*TestCombinedMetrics)(&cm)
+	return &TestCombinedMetrics{
+		key:   cfg.key,
+		value: &cm,
+	}
 }
 
 func (tcm *TestCombinedMetrics) GetProto() *aggregationpb.CombinedMetrics {
-	cm := (*combinedMetrics)(tcm)
-	cmproto := cm.ToProto()
-	return cmproto
+	return tcm.value.ToProto()
 }
 
 func (tcm *TestCombinedMetrics) Get() combinedMetrics {
-	cm := (*combinedMetrics)(tcm)
-	return *cm
+	return *tcm.value
+}
+
+func (tcm *TestCombinedMetrics) GetKey() CombinedMetricsKey {
+	return tcm.key
 }
 
 type TestServiceMetrics struct {
@@ -148,8 +163,8 @@ type TestServiceMetrics struct {
 func (tcm *TestCombinedMetrics) AddServiceMetrics(
 	sk serviceAggregationKey,
 ) *TestServiceMetrics {
-	if _, ok := tcm.Services[sk]; !ok {
-		tcm.Services[sk] = newServiceMetrics()
+	if _, ok := tcm.value.Services[sk]; !ok {
+		tcm.value.Services[sk] = newServiceMetrics()
 	}
 	return &TestServiceMetrics{sk: sk, tcm: tcm}
 }
@@ -157,12 +172,12 @@ func (tcm *TestCombinedMetrics) AddServiceMetrics(
 func (tcm *TestCombinedMetrics) AddServiceMetricsOverflow(
 	sk serviceAggregationKey,
 ) *TestServiceMetrics {
-	if _, ok := tcm.Services[sk]; ok {
+	if _, ok := tcm.value.Services[sk]; ok {
 		panic("service already added as non overflow")
 	}
 
 	hash := protohash.HashServiceAggregationKey(xxhash.Digest{}, sk.ToProto())
-	insertHash(&tcm.OverflowServicesEstimator, hash.Sum64())
+	insertHash(&tcm.value.OverflowServicesEstimator, hash.Sum64())
 
 	// Does not save to a map, any service instance added to this will
 	// automatically be overflowed to the global overflow bucket.
@@ -189,7 +204,7 @@ func (tsm *TestServiceMetrics) AddTransaction(
 	ktm.Metrics = aggregationpb.TransactionMetricsFromVTPool()
 	ktm.Metrics.Histogram = histogramToProto(hdr)
 
-	svc := tsm.tcm.Services[tsm.sk]
+	svc := tsm.tcm.value.Services[tsm.sk]
 	if oldKtm, ok := svc.TransactionGroups[tk]; ok {
 		mergeKeyedTransactionMetrics(oldKtm, ktm)
 		ktm = oldKtm
@@ -219,12 +234,12 @@ func (tsm *TestServiceMetrics) AddTransactionOverflow(
 	)
 	if tsm.overflow {
 		// Global overflow
-		tsm.tcm.OverflowServices.OverflowTransaction.Merge(from, hash.Sum64())
+		tsm.tcm.value.OverflowServices.OverflowTransaction.Merge(from, hash.Sum64())
 	} else {
 		// Per service overflow
-		svc := tsm.tcm.Services[tsm.sk]
+		svc := tsm.tcm.value.Services[tsm.sk]
 		svc.OverflowGroups.OverflowTransaction.Merge(from, hash.Sum64())
-		tsm.tcm.Services[tsm.sk] = svc
+		tsm.tcm.value.Services[tsm.sk] = svc
 	}
 	return tsm
 }
@@ -251,7 +266,7 @@ func (tsm *TestServiceMetrics) AddServiceTransaction(
 		kstm.Metrics.SuccessCount = float64(cfg.count)
 	}
 
-	svc := tsm.tcm.Services[tsm.sk]
+	svc := tsm.tcm.value.Services[tsm.sk]
 	if oldKstm, ok := svc.ServiceTransactionGroups[stk]; ok {
 		mergeKeyedServiceTransactionMetrics(oldKstm, kstm)
 		kstm = oldKstm
@@ -286,12 +301,12 @@ func (tsm *TestServiceMetrics) AddServiceTransactionOverflow(
 	)
 	if tsm.overflow {
 		// Global overflow
-		tsm.tcm.OverflowServices.OverflowServiceTransaction.Merge(from, hash.Sum64())
+		tsm.tcm.value.OverflowServices.OverflowServiceTransaction.Merge(from, hash.Sum64())
 	} else {
 		// Per service overflow
-		svc := tsm.tcm.Services[tsm.sk]
+		svc := tsm.tcm.value.Services[tsm.sk]
 		svc.OverflowGroups.OverflowServiceTransaction.Merge(from, hash.Sum64())
-		tsm.tcm.Services[tsm.sk] = svc
+		tsm.tcm.value.Services[tsm.sk] = svc
 	}
 	return tsm
 }
@@ -311,7 +326,7 @@ func (tsm *TestServiceMetrics) AddSpan(
 	ksm.Metrics.Sum += float64(cfg.duration * time.Duration(cfg.count))
 	ksm.Metrics.Count += float64(cfg.count)
 
-	svc := tsm.tcm.Services[tsm.sk]
+	svc := tsm.tcm.value.Services[tsm.sk]
 	if oldKsm, ok := svc.SpanGroups[spk]; ok {
 		mergeKeyedSpanMetrics(oldKsm, ksm)
 		ksm = oldKsm
@@ -339,12 +354,12 @@ func (tsm *TestServiceMetrics) AddSpanOverflow(
 	)
 	if tsm.overflow {
 		// Global overflow
-		tsm.tcm.OverflowServices.OverflowSpan.Merge(from, hash.Sum64())
+		tsm.tcm.value.OverflowServices.OverflowSpan.Merge(from, hash.Sum64())
 	} else {
 		// Per service overflow
-		svc := tsm.tcm.Services[tsm.sk]
+		svc := tsm.tcm.value.Services[tsm.sk]
 		svc.OverflowGroups.OverflowSpan.Merge(from, hash.Sum64())
-		tsm.tcm.Services[tsm.sk] = svc
+		tsm.tcm.value.Services[tsm.sk] = svc
 	}
 	return tsm
 }
@@ -355,6 +370,10 @@ func (tsm *TestServiceMetrics) GetProto() *aggregationpb.CombinedMetrics {
 
 func (tsm *TestServiceMetrics) Get() combinedMetrics {
 	return tsm.tcm.Get()
+}
+
+func (tsm *TestServiceMetrics) GetTest() *TestCombinedMetrics {
+	return tsm.tcm
 }
 
 // Set of cmp options to sort combined metrics based on key hash. Hash collisions

--- a/aggregators/config.go
+++ b/aggregators/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	Partitions             uint16
 	AggregationIntervals   []time.Duration
 	HarvestDelay           time.Duration
-	MaxLookback            time.Duration
+	Lookback               time.Duration
 	CombinedMetricsIDToKVs func([16]byte) []attribute.KeyValue
 	InMemory               bool
 
@@ -141,23 +141,23 @@ func WithHarvestDelay(delay time.Duration) Option {
 	}
 }
 
-// WithMaxLookback configures the maximum duration that the
+// WithLookback configures the maximum duration that the
 // aggregator will use to query the database during harvest time
 // in addition to the original period derived from aggregation
 // interval i.e. the harvest interval for each aggregation interval
-// will be defined as [end-MaxLookback-AggregationIvl, end).
+// will be defined as [end-Lookback-AggregationIvl, end).
 //
-// The main purpose of MaxLookback is to protect against data loss for
+// The main purpose of Lookback is to protect against data loss for
 // multi level deployments of aggregators where AggregateCombinedMetrics
 // is used to aggregate partial aggregates. In these cases, the
-// MaxLookback configuration can protect against data loss due to
+// Lookback configuration can protect against data loss due to
 // delayed partial aggregates. Note that these delayed partial
 // aggregates will only be aggregated with other delayed partial
 // aggregates and thus we can have multiple aggregated metrics for
 // the same CombinedMetricsKey{Interval, ProcessingTime, ID}.
-func WithMaxLookback(lookback time.Duration) Option {
+func WithLookback(lookback time.Duration) Option {
 	return func(c Config) Config {
-		c.MaxLookback = lookback
+		c.Lookback = lookback
 		return c
 	}
 }

--- a/aggregators/config_test.go
+++ b/aggregators/config_test.go
@@ -91,13 +91,13 @@ func TestNewConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "with_max_lookback",
+			name: "with_lookback",
 			opts: []Option{
-				WithMaxLookback(time.Hour),
+				WithLookback(time.Hour),
 			},
 			expected: func() Config {
 				cfg := defaultCfg
-				cfg.MaxLookback = time.Hour
+				cfg.Lookback = time.Hour
 				return cfg
 			},
 		},

--- a/aggregators/config_test.go
+++ b/aggregators/config_test.go
@@ -91,6 +91,17 @@ func TestNewConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "with_max_lookback",
+			opts: []Option{
+				WithMaxLookback(time.Hour),
+			},
+			expected: func() Config {
+				cfg := defaultCfg
+				cfg.MaxLookback = time.Hour
+				return cfg
+			},
+		},
+		{
 			name: "with_meter",
 			opts: []Option{
 				WithMeter(customMeter),


### PR DESCRIPTION
Introduce max lookback period which configures the maximum duration that the aggregator will use to query the database during harvest time in addition to the original period derived from aggregation interval i.e. the harvest interval for each aggregation interval will be defined as `[end-MaxLookback-AggregationIvl, end)`.

The main purpose of `MaxLookback` is to protect against data loss for multi level deployments of aggregators where AggregateCombinedMetrics is used to aggregate partial aggregates. In these cases, the MaxLookback configuration can protect against data loss due to delayed partial aggregates (see test case). Note that these delayed partial aggregates will only be aggregated with other delayed partial aggregates and thus we can have multiple aggregated metrics for
the same `CombinedMetricsKey{Interval, ProcessingTime, ID}` (see test case).

`MaxLookback` can be configured based on retention period.

Closes: #94 
