### PR TITLE
Reduce public api

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -339,7 +339,7 @@ func (a *Aggregator) aggregateAPMEvent(
 		totalBytesIn += bytesIn
 		return err
 	}
-	err := EventToCombinedMetrics(e, cmk, a.cfg.Partitions, aggregateFunc)
+	err := eventToCombinedMetrics(e, cmk, a.cfg.Partitions, aggregateFunc)
 	if err != nil {
 		return 0, fmt.Errorf("failed to aggregate combined metrics: %w", err)
 	}

--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -47,7 +47,7 @@ var (
 type Aggregator struct {
 	db           *pebble.DB
 	writeOptions *pebble.WriteOptions
-	cfg          Config
+	cfg          config
 
 	mu             sync.Mutex
 	processingTime time.Time
@@ -64,7 +64,7 @@ type Aggregator struct {
 //
 // Close must be called when the the aggregator is no longer needed.
 func New(opts ...Option) (*Aggregator, error) {
-	cfg, err := NewConfig(opts...)
+	cfg, err := newConfig(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create aggregation config: %w", err)
 	}

--- a/aggregators/codec.go
+++ b/aggregators/codec.go
@@ -317,7 +317,7 @@ func (o *overflow) FromProto(pb *aggregationpb.Overflow) {
 }
 
 // ToProto converts GlobalLabels to its protobuf representation.
-func (gl *GlobalLabels) ToProto() *aggregationpb.GlobalLabels {
+func (gl *globalLabels) ToProto() *aggregationpb.GlobalLabels {
 	pb := aggregationpb.GlobalLabelsFromVTPool()
 
 	// Keys must be sorted to ensure wire formats are deterministically generated and strings are directly comparable
@@ -355,8 +355,8 @@ func (gl *GlobalLabels) ToProto() *aggregationpb.GlobalLabels {
 	return pb
 }
 
-// FromProto converts protobuf representation to GlobalLabels.
-func (gl *GlobalLabels) FromProto(pb *aggregationpb.GlobalLabels) {
+// FromProto converts protobuf representation to globalLabels.
+func (gl *globalLabels) FromProto(pb *aggregationpb.GlobalLabels) {
 	gl.Labels = make(modelpb.Labels, len(pb.Labels))
 	for _, l := range pb.Labels {
 		gl.Labels[l.Key] = &modelpb.LabelValue{Value: l.Value, Values: l.Values, Global: true}
@@ -367,8 +367,8 @@ func (gl *GlobalLabels) FromProto(pb *aggregationpb.GlobalLabels) {
 	}
 }
 
-// MarshalBinary marshals GlobalLabels to binary using protobuf.
-func (gl *GlobalLabels) MarshalBinary() ([]byte, error) {
+// MarshalBinary marshals globalLabels to binary using protobuf.
+func (gl *globalLabels) MarshalBinary() ([]byte, error) {
 	if gl.Labels == nil && gl.NumericLabels == nil {
 		return nil, nil
 	}
@@ -377,14 +377,14 @@ func (gl *GlobalLabels) MarshalBinary() ([]byte, error) {
 	return pb.MarshalVT()
 }
 
-// MarshalString marshals GlobalLabels to string from binary using protobuf.
-func (gl *GlobalLabels) MarshalString() (string, error) {
+// MarshalString marshals globalLabels to string from binary using protobuf.
+func (gl *globalLabels) MarshalString() (string, error) {
 	b, err := gl.MarshalBinary()
 	return string(b), err
 }
 
-// UnmarshalBinary unmarshals binary protobuf to GlobalLabels.
-func (gl *GlobalLabels) UnmarshalBinary(data []byte) error {
+// UnmarshalBinary unmarshals binary protobuf to globalLabels.
+func (gl *globalLabels) UnmarshalBinary(data []byte) error {
 	if len(data) == 0 {
 		gl.Labels = nil
 		gl.NumericLabels = nil
@@ -399,8 +399,8 @@ func (gl *GlobalLabels) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-// UnmarshalString unmarshals string of binary protobuf to GlobalLabels.
-func (gl *GlobalLabels) UnmarshalString(data string) error {
+// UnmarshalString unmarshals string of binary protobuf to globalLabels.
+func (gl *globalLabels) UnmarshalString(data string) error {
 	return gl.UnmarshalBinary([]byte(data))
 }
 

--- a/aggregators/codec_test.go
+++ b/aggregators/codec_test.go
@@ -52,7 +52,7 @@ func TestGetEncodedCombinedMetricsKeyWithoutPartitionID(t *testing.T) {
 }
 
 func TestGlobalLabels(t *testing.T) {
-	expected := GlobalLabels{
+	expected := globalLabels{
 		Labels: map[string]*modelpb.LabelValue{
 			"lb01": {
 				Values: []string{"test01", "test02"},
@@ -68,7 +68,7 @@ func TestGlobalLabels(t *testing.T) {
 	}
 	str, err := expected.MarshalString()
 	assert.NoError(t, err)
-	var actual GlobalLabels
+	var actual globalLabels
 	assert.NoError(t, actual.UnmarshalString(str))
 	assert.Empty(t, cmp.Diff(
 		expected, actual,

--- a/aggregators/config.go
+++ b/aggregators/config.go
@@ -34,8 +34,8 @@ type Processor func(
 	aggregationIvl time.Duration,
 ) error
 
-// Config contains the required config for running the aggregator.
-type Config struct {
+// config contains the required config for running the aggregator.
+type config struct {
 	DataDir                string
 	Limits                 Limits
 	Processor              Processor
@@ -53,10 +53,10 @@ type Config struct {
 }
 
 // Option allows configuring aggregator based on functional options.
-type Option func(Config) Config
+type Option func(config) config
 
 // NewConfig creates a new aggregator config based on the passed options.
-func NewConfig(opts ...Option) (Config, error) {
+func newConfig(opts ...Option) (config, error) {
 	cfg := defaultCfg()
 	for _, opt := range opts {
 		cfg = opt(cfg)
@@ -66,7 +66,7 @@ func NewConfig(opts ...Option) (Config, error) {
 
 // WithDataDir configures the data directory to be used by the database.
 func WithDataDir(dataDir string) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.DataDir = dataDir
 		return c
 	}
@@ -74,7 +74,7 @@ func WithDataDir(dataDir string) Option {
 
 // WithLimits configures the limits to be used by the aggregator.
 func WithLimits(limits Limits) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.Limits = limits
 		return c
 	}
@@ -88,7 +88,7 @@ func WithLimits(limits Limits) Option {
 // can no longer access the pooled objects, then the Processor should
 // release the objects back to the pool.
 func WithProcessor(processor Processor) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.Processor = processor
 		return c
 	}
@@ -101,7 +101,7 @@ func WithProcessor(processor Processor) Option {
 // combined metric are listed before any other if compared using the bytes
 // comparer.
 func WithPartitions(n uint16) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.Partitions = n
 		return c
 	}
@@ -110,7 +110,7 @@ func WithPartitions(n uint16) Option {
 // WithAggregationIntervals defines the intervals that aggregator will
 // aggregate for.
 func WithAggregationIntervals(aggIvls []time.Duration) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.AggregationIntervals = aggIvls
 		return c
 	}
@@ -135,7 +135,7 @@ func WithAggregationIntervals(aggIvls []time.Duration) Option {
 // metrics are aggregated. This is because AggregateBatch API is
 // not used by the l2 aggregator.
 func WithHarvestDelay(delay time.Duration) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.HarvestDelay = delay
 		return c
 	}
@@ -156,7 +156,7 @@ func WithHarvestDelay(delay time.Duration) Option {
 // aggregates and thus we can have multiple aggregated metrics for
 // the same CombinedMetricsKey{Interval, ProcessingTime, ID}.
 func WithLookback(lookback time.Duration) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.Lookback = lookback
 		return c
 	}
@@ -165,7 +165,7 @@ func WithLookback(lookback time.Duration) Option {
 // WithMeter defines a custom meter which will be used for collecting
 // telemetry. Defaults to the meter provided by global provider.
 func WithMeter(meter metric.Meter) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.Meter = meter
 		return c
 	}
@@ -174,7 +174,7 @@ func WithMeter(meter metric.Meter) Option {
 // WithTracer defines a custom tracer which will be used for collecting
 // traces. Defaults to the tracer provided by global provider.
 func WithTracer(tracer trace.Tracer) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.Tracer = tracer
 		return c
 	}
@@ -183,7 +183,7 @@ func WithTracer(tracer trace.Tracer) Option {
 // WithCombinedMetricsIDToKVs defines a function that converts a combined
 // metrics ID to zero or more attribute.KeyValue for telemetry.
 func WithCombinedMetricsIDToKVs(f func([16]byte) []attribute.KeyValue) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.CombinedMetricsIDToKVs = f
 		return c
 	}
@@ -191,7 +191,7 @@ func WithCombinedMetricsIDToKVs(f func([16]byte) []attribute.KeyValue) Option {
 
 // WithLogger defines a custom logger to be used by aggregator.
 func WithLogger(logger *zap.Logger) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.Logger = logger
 		return c
 	}
@@ -202,7 +202,7 @@ func WithLogger(logger *zap.Logger) Option {
 // Logging of overflows is disabled by default, as most callers are expected to rely on
 // metrics to surface cardinality issues. Support for logging exists for historical reasons.
 func WithOverflowLogging(enabled bool) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.OverflowLogging = enabled
 		return c
 	}
@@ -210,14 +210,14 @@ func WithOverflowLogging(enabled bool) Option {
 
 // WithInMemory defines whether aggregator uses in-memory file system.
 func WithInMemory(enabled bool) Option {
-	return func(c Config) Config {
+	return func(c config) config {
 		c.InMemory = enabled
 		return c
 	}
 }
 
-func defaultCfg() Config {
-	return Config{
+func defaultCfg() config {
+	return config{
 		DataDir:                "/tmp",
 		Processor:              stdoutProcessor,
 		Partitions:             1,
@@ -229,7 +229,7 @@ func defaultCfg() Config {
 	}
 }
 
-func validateCfg(cfg Config) error {
+func validateCfg(cfg config) error {
 	if cfg.DataDir == "" {
 		return errors.New("data directory is required")
 	}

--- a/aggregators/config_test.go
+++ b/aggregators/config_test.go
@@ -20,13 +20,13 @@ func TestNewConfig(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
 		opts             []Option
-		expected         func() Config
+		expected         func() config
 		expectedErrorMsg string
 	}{
 		{
 			name: "empty",
 			opts: nil,
-			expected: func() Config {
+			expected: func() config {
 				return defaultCfg
 			},
 		},
@@ -35,7 +35,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []Option{
 				WithDataDir("/test"),
 			},
-			expected: func() Config {
+			expected: func() config {
 				cfg := defaultCfg
 				cfg.DataDir = "/test"
 				return cfg
@@ -54,7 +54,7 @@ func TestNewConfig(t *testing.T) {
 					MaxServiceTransactionGroupsPerService: 10,
 				}),
 			},
-			expected: func() Config {
+			expected: func() config {
 				cfg := defaultCfg
 				cfg.Limits = Limits{
 					MaxServices:                           10,
@@ -73,7 +73,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []Option{
 				WithAggregationIntervals([]time.Duration{time.Minute, time.Hour}),
 			},
-			expected: func() Config {
+			expected: func() config {
 				cfg := defaultCfg
 				cfg.AggregationIntervals = []time.Duration{time.Minute, time.Hour}
 				return cfg
@@ -84,7 +84,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []Option{
 				WithHarvestDelay(time.Hour),
 			},
-			expected: func() Config {
+			expected: func() config {
 				cfg := defaultCfg
 				cfg.HarvestDelay = time.Hour
 				return cfg
@@ -95,7 +95,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []Option{
 				WithLookback(time.Hour),
 			},
-			expected: func() Config {
+			expected: func() config {
 				cfg := defaultCfg
 				cfg.Lookback = time.Hour
 				return cfg
@@ -106,7 +106,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []Option{
 				WithMeter(customMeter),
 			},
-			expected: func() Config {
+			expected: func() config {
 				cfg := defaultCfg
 				cfg.Meter = customMeter
 				return cfg
@@ -117,7 +117,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []Option{
 				WithTracer(customTracer),
 			},
-			expected: func() Config {
+			expected: func() config {
 				cfg := defaultCfg
 				cfg.Tracer = customTracer
 				return cfg
@@ -173,7 +173,7 @@ func TestNewConfig(t *testing.T) {
 			expectedErrorMsg: "aggregation interval greater than 18 hours is not supported",
 		},
 	} {
-		actual, err := NewConfig(tc.opts...)
+		actual, err := newConfig(tc.opts...)
 
 		if tc.expectedErrorMsg != "" {
 			assert.EqualError(t, err, tc.expectedErrorMsg)

--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -51,7 +51,7 @@ type partitionedMetricsBuilder struct {
 
 	// We reuse a single CombinedMetrics for all partitions, by iterating
 	// through each partition's metrics and setting them on the CombinedMetrics
-	// before invoking the callback in EventToCombinedMetrics.
+	// before invoking the callback in eventToCombinedMetrics.
 	combinedMetrics aggregationpb.CombinedMetrics
 }
 
@@ -301,16 +301,16 @@ func (mb *eventMetricsBuilder) release() {
 	eventMetricsBuilderPool.Put(mb)
 }
 
-// EventToCombinedMetrics converts APMEvent to one or more CombinedMetrics and
+// eventToCombinedMetrics converts APMEvent to one or more CombinedMetrics and
 // calls the provided callback for each pair of CombinedMetricsKey and
 // CombinedMetrics. The callback MUST NOT hold the reference of the passed
 // CombinedMetrics. If required, the callback can call CloneVT to clone the
 // CombinedMetrics. If an event results in multiple metrics, they may be spread
 // across different partitions.
 //
-// EventToCombinedMetrics will never produce overflow metrics, as it applies to a
+// eventToCombinedMetrics will never produce overflow metrics, as it applies to a
 // single APMEvent.
-func EventToCombinedMetrics(
+func eventToCombinedMetrics(
 	e *modelpb.APMEvent,
 	unpartitionedKey CombinedMetricsKey,
 	partitions uint16,

--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -420,7 +420,7 @@ func CombinedMetricsToBatch(
 	for _, ksm := range cm.ServiceMetrics {
 		sk, sm := ksm.Key, ksm.Metrics
 
-		var gl GlobalLabels
+		var gl globalLabels
 		if err := gl.UnmarshalBinary(sk.GlobalLabelsStr); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal global labels: %w", err)
 		}

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -333,7 +333,7 @@ func TestEventToCombinedMetrics(t *testing.T) {
 				return nil
 			}
 			for _, e := range tc.input() {
-				err := EventToCombinedMetrics(e, cmk, tc.partitions, collector)
+				err := eventToCombinedMetrics(e, cmk, tc.partitions, collector)
 				require.NoError(t, err)
 			}
 			assert.Empty(t, cmp.Diff(
@@ -571,7 +571,7 @@ func BenchmarkEventToCombinedMetrics(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := EventToCombinedMetrics(event, cmk, 1 /*partitions*/, noop)
+		err := eventToCombinedMetrics(event, cmk, 1 /*partitions*/, noop)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -769,7 +769,7 @@ func createTestSpanMetric(
 
 func getTestGlobalLabelsStr(t *testing.T, s string) string {
 	t.Helper()
-	var gl GlobalLabels
+	var gl globalLabels
 	gl.Labels = make(modelpb.Labels)
 	gl.Labels["test"] = &modelpb.LabelValue{Value: s}
 	gls, err := gl.MarshalString()
@@ -828,7 +828,7 @@ func TestMarshalEventGlobalLabels(t *testing.T) {
 	}
 	b, err := marshalEventGlobalLabels(e)
 	require.NoError(t, err)
-	gl := GlobalLabels{}
+	gl := globalLabels{}
 	err = gl.UnmarshalBinary(b)
 	require.NoError(t, err)
 	assert.Equal(t, modelpb.Labels{

--- a/aggregators/models.go
+++ b/aggregators/models.go
@@ -70,10 +70,10 @@ type CombinedMetricsKey struct {
 	ID             [16]byte
 }
 
-// GlobalLabels is an intermediate struct used to marshal/unmarshal the
+// globalLabels is an intermediate struct used to marshal/unmarshal the
 // provided global labels into a comparable format. The format is used by
 // pebble db to compare service aggregation keys.
-type GlobalLabels struct {
+type globalLabels struct {
 	Labels        modelpb.Labels
 	NumericLabels modelpb.NumericLabels
 }


### PR DESCRIPTION
This is an attempt to reduce the size of the public API in the `aggregators` package, as a first step towards making it easier to grasp.

It:

* Makes the config private. We don't need to access the config struct, we pass config as functional parameters.
* Makes `GlobalLabels` private. This struct is only used within that package.
* Makes `EventToCombinedMetrics` private, as it's also only used within that package.