### PR TITLE
ci: don't run workflow twice in a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
-on: ["push", "pull_request"]
+on:
+  push:
+    branches:
+      - main
+  pull_request: ~
 
 permissions:
   contents: read


### PR DESCRIPTION
## Details

In the current configuration the workflow runs twice in a PR, because it runs for the `pull_request` event and for the `push` event on the branch. 

This way, it will only be triggered for pushes to the `main` branch and on `pull_request` events.