### PR TITLE
github-actions: use ephemeral tokens

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -11,7 +11,18 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "organization_projects": "write",
+              "issues": "read"
+            }
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/elastic/projects/1286
-          github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
No more finer-grained tokens but ephemeral tokens using a GH app

