### PR TITLE
testing: expose convert and merge as public

### DIFF
--- a/aggregators/aggregator.go
+++ b/aggregators/aggregator.go
@@ -357,7 +357,7 @@ func (a *Aggregator) aggregateAPMEvent(
 		totalBytesIn += bytesIn
 		return err
 	}
-	err := eventToCombinedMetrics(e, cmk, a.cfg.Partitions, aggregateFunc)
+	err := EventToCombinedMetrics(e, cmk, a.cfg.Partitions, aggregateFunc)
 	if err != nil {
 		return 0, fmt.Errorf("failed to aggregate combined metrics: %w", err)
 	}

--- a/aggregators/converter.go
+++ b/aggregators/converter.go
@@ -302,16 +302,16 @@ func (mb *eventMetricsBuilder) release() {
 	eventMetricsBuilderPool.Put(mb)
 }
 
-// eventToCombinedMetrics converts APMEvent to one or more CombinedMetrics and
+// EventToCombinedMetrics converts APMEvent to one or more CombinedMetrics and
 // calls the provided callback for each pair of CombinedMetricsKey and
 // CombinedMetrics. The callback MUST NOT hold the reference of the passed
 // CombinedMetrics. If required, the callback can call CloneVT to clone the
 // CombinedMetrics. If an event results in multiple metrics, they may be spread
 // across different partitions.
 //
-// eventToCombinedMetrics will never produce overflow metrics, as it applies to a
+// EventToCombinedMetrics will never produce overflow metrics, as it applies to a
 // single APMEvent.
-func eventToCombinedMetrics(
+func EventToCombinedMetrics(
 	e *modelpb.APMEvent,
 	unpartitionedKey CombinedMetricsKey,
 	partitions uint16,

--- a/aggregators/converter_test.go
+++ b/aggregators/converter_test.go
@@ -334,7 +334,7 @@ func TestEventToCombinedMetrics(t *testing.T) {
 				return nil
 			}
 			for _, e := range tc.input() {
-				err := eventToCombinedMetrics(e, cmk, tc.partitions, collector)
+				err := EventToCombinedMetrics(e, cmk, tc.partitions, collector)
 				require.NoError(t, err)
 			}
 			assert.Empty(t, cmp.Diff(
@@ -569,7 +569,7 @@ func BenchmarkEventToCombinedMetrics(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := eventToCombinedMetrics(event, cmk, 1 /*partitions*/, noop)
+		err := EventToCombinedMetrics(event, cmk, 1 /*partitions*/, noop)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/aggregators/merger.go
+++ b/aggregators/merger.go
@@ -448,3 +448,15 @@ func newConstraints(limits Limits) constraints {
 		totalSpanGroups:               constraint.New(0, limits.MaxSpanGroups),
 	}
 }
+
+// MergeCombinedMetrics merges provided CombinedMetrics together.
+func MergeCombinedMetrics(limits Limits, metrics ...*aggregationpb.CombinedMetrics) *aggregationpb.CombinedMetrics {
+	merger := combinedMetricsMerger{
+		limits:      limits,
+		constraints: newConstraints(limits),
+	}
+	for _, m := range metrics {
+		merger.merge(m)
+	}
+	return merger.metrics.ToProto()
+}


### PR DESCRIPTION
This PR exposes `EventToCombinedMetrics` and `MergeCombinedMetrics` internal functionality as a part of public API. This is useful for testing purposes and allows to easily implement simple aggregation logic in memory bypassing badger. 